### PR TITLE
Update feature-level AddMetaData

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 4.9.9.9089
+Version: 4.9.9.9090
 Date: 2023-07-07
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),

--- a/R/assay.R
+++ b/R/assay.R
@@ -252,7 +252,20 @@ CreateAssayObject <- function(
 #' @export
 #' @method AddMetaData Assay
 #'
-AddMetaData.Assay <- .AddMetaData
+AddMetaData.Assay <- function(object, metadata, col.name = NULL) {
+  if (is.null(x = col.name) && (is.atomic(x = metadata) && !is.matrix(x = metadata))) {
+    abort(message = "'col.name' must be provided for atomic meta data")
+  }
+  if (inherits(x = metadata, what = c('matrix', 'Matrix'))) {
+    metadata <- as.data.frame(x = metadata)
+  }
+  col.name <- col.name %||% names(x = metadata) %||% colnames(x = metadata)
+  if (is.null(x = col.name)) {
+    abort(message = "No metadata name provided and could not infer it from metadata object")
+  }
+  object[col.name] <- metadata
+  return(object)
+}
 
 #' @rdname DefaultAssay
 #' @export

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -410,7 +410,20 @@ setClass(
 #'
 #' @method AddMetaData StdAssay
 #'
-AddMetaData.StdAssay <- .AddMetaData
+AddMetaData.StdAssay <- function(object, metadata, col.name = NULL) {
+  if (is.null(x = col.name) && (is.atomic(x = metadata) && !is.matrix(x = metadata))) {
+    abort(message = "'col.name' must be provided for atomic meta data")
+  }
+  if (inherits(x = metadata, what = c('matrix', 'Matrix'))) {
+    metadata <- as.data.frame(x = metadata)
+  }
+  col.name <- col.name %||% names(x = metadata) %||% colnames(x = metadata)
+  if (is.null(x = col.name)) {
+    abort(message = "No metadata name provided and could not infer it from metadata object")
+  }
+  object[col.name] <- metadata
+  return(object)
+}
 
 #' @rdname AddMetaData
 #' @method AddMetaData Assay5


### PR DESCRIPTION
Fixes adding feature metadata to assay which changed from double bracket to single bracket:

```r
# v4
object[["RNA"]][[col.name]] <- metadata

# v5
object[["RNA"]][col.name] <- metadata
```