### PR TITLE
subset.Seurat: Making downsample specific to default assay

### DIFF
--- a/R/seurat.R
+++ b/R/seurat.R
@@ -3719,6 +3719,11 @@ subset.Seurat <- function(
   ...
 ) {
   var.features <- VariableFeatures(object = x)
+  args <- list(...)
+  if ("downsample" %in% names(args) & is.null(cells)) {
+    message('Downsampling ', args$downsample, ' cells from "', DefaultAssay(x), '" assay')
+    cells <- colnames(x[[DefaultAssay(x)]])
+  }
   if (!missing(x = subset)) {
     subset <- enquo(arg = subset)
   }


### PR DESCRIPTION
In [this issue](https://github.com/satijalab/seurat/issues/7843), a user referenced a `DoHeatmap` error. This led to the realization that if you run `subset()` on an object with a sketched assay (that is the default assay and has less cells than the entire object) --> `subset()` would pull cells from the entire object, meaning that the actual number of cells that were sampled in the default assay was less than the number that was intended to be downsampled by the user. 

This is a small change to just specify that the cells will be pulled from the colnames() of the default assay when downsample is set as an argument. We also add a message to ensure users know which cells are being pulled. 

Currently, if you set `subset = ` or `idents =`, we will still pick from all cells in the object. I left it this way as I think when people subset with a category the expected behavior is to get all the cells from that category in the object

```
> a <- subset(obj, downsample=1000)
Downsampling 1000 cells from "sketch_og" assay
# If you set your own cells, this is ignored
> a <- subset(obj, cells = colnames(obj)[1:2000], downsample=1000)
```

The DoHeatmap part of this was also fixed at https://github.com/satijalab/seurat-private/pull/813, so if the feeling is that users would intend to downsample from the whole object we don't have to merge this. 
