### PR TITLE
Fix reexport of `%||%`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.1.9001
+Version: 5.0.1.9002
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Changes:
+- Properly re-export `%||%` from rlang (#178)
+
 # SeuratObject 5.0.1
 
 ## Changes:

--- a/R/utils.R
+++ b/R/utils.R
@@ -19,13 +19,13 @@ NULL
 #'
 #' Set a default value depending on if an object is \code{NULL}
 #'
+#' @usage x \%||\% y
+#'
 #' @param x An object to test
 #' @param y A default value
 #'
 #' @return For \code{\%||\%}: \code{y} if \code{x} is \code{NULL};
 #' otherwise \code{x}
-#'
-#' @importFrom rlang %||%
 #'
 #' @name set-if-null
 #' @rdname set-if-null
@@ -34,7 +34,7 @@ NULL
 #'
 #' @seealso \code{\link[rlang:op-null-default]{rlang::\%||\%}}
 #'
-#' @export
+#' @aliases %||%
 #'
 #' @concept utils
 #'
@@ -43,7 +43,14 @@ NULL
 #' 1 %||% 2
 #' NULL %||% 2
 #'
-`%||%` <- rlang::`%||%`
+NULL
+
+#' @importFrom rlang %||%
+#' @export
+#'
+#' @noRd
+#'
+rlang::`%||%`
 
 #' @rdname set-if-null
 #'


### PR DESCRIPTION
Adjust reexport of `%||%` to be a proper reexport instead of a redefine. This should hopefully silence warnings in scCustomize

fixes #177