### PR TITLE
Fixes error in UpdateSeuratObject due to missing global slot.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.1.9003
+Version: 5.0.1.9004
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Properly re-export `%||%` from rlang (#178)
 - Class key-based warnings (#180)
 - Require R 4.1 (#180)
+- Fix errors in `UpdateSeuratObject` (@ddiez, #182)
 
 # SeuratObject 5.0.1
 

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -5874,6 +5874,7 @@ UpdateDimReduction <- function(old.dr, assay) {
       cell.embeddings = as(object = cell.embeddings, Class = 'matrix'),
       feature.loadings = as(object = feature.loadings, Class = 'matrix'),
       assay.used = assay,
+      global = FALSE,
       stdev = as(object = stdev, Class = 'numeric'),
       key = as(object = new.key, Class = 'character'),
       jackstraw = new.jackstraw,


### PR DESCRIPTION
This fixes the issue in Seurat's UpdateSeuratObject: https://github.com/satijalab/seurat/issues/8019

When updating the DimReduc objects the slot "global" is not initialized, it is only assigned for the default reduction. This fix initializes it to FALSE when running UpdateDimReduction.