### PR TITLE
Add warning if layer is absent from assay

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.1.9009
+Version: 5.0.1.9010
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 - Fix bug in `PolyVtx` (#194)
 - Fix bug in feature-level subsetting (#200)
 - Update `UpdateSeuratObject` to run without `Seurat` installed (#199)
+- Add warning in `Layers.Assay()` when the search returns no results (@maxim-h, #189)
 
 # SeuratObject 5.0.1
 

--- a/R/assay.R
+++ b/R/assay.R
@@ -697,6 +697,11 @@ Layers.Assay <- function(object, search = NA, ...) {
   if (!is_na(x = search)) {
     layers <- intersect(x = search, y = layers)
     if (length(x = layers) == 0) {
+      warning(
+        "Layer ", search, " isn't present in the assay ", deparse(substitute(object)), ". Returning NULL.",
+        call. = FALSE,
+        immediate. = TRUE
+      )
       return(NULL)
     }
   }

--- a/R/assay.R
+++ b/R/assay.R
@@ -698,7 +698,11 @@ Layers.Assay <- function(object, search = NA, ...) {
     layers <- intersect(x = search, y = layers)
     if (length(x = layers) == 0) {
       warning(
-        "Layer ", search, " isn't present in the assay ", deparse(substitute(object)), ". Returning NULL.",
+        "Layer ",
+        search,
+        " isn't present in the assay ",
+        deparse(expr = substitute(expr = object)),
+        "; returning NULL",
         call. = FALSE,
         immediate. = TRUE
       )


### PR DESCRIPTION
This is meant to help diagnose issues when assay doesn't have desired layer.  For example see satijalab/seurat#8658 and discussion in satijalab/seurat#8659, specifically the [suggestion from Sam](https://github.com/satijalab/seurat/pull/8659#issuecomment-2009820323).

The warning message might not be the prettiest, but I didn't want to go through `Layer.Seurat` method to get the assay name.