### PR TITLE
Allow Radius to accept params

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.1.9004
+Version: 5.0.1.9005
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),
@@ -36,7 +36,7 @@ BugReports: https://github.com/satijalab/seurat-object/issues
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Additional_repositories:
     https://bnprks.r-universe.dev
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Changes:
+- Add `...` to call signature for `Radius` generic
 - Properly re-export `%||%` from rlang (#178)
 - Class key-based warnings (#180)
 - Require R 4.1 (#180)

--- a/R/centroids.R
+++ b/R/centroids.R
@@ -192,7 +192,7 @@ GetTissueCoordinates.Centroids <- function(object, full = TRUE, ...) {
 #' @method Radius Centroids
 #' @export
 #'
-Radius.Centroids <- function(object) {
+Radius.Centroids <- function(object, ...) {
   return(slot(object = object, name = 'radius'))
 }
 

--- a/R/generics.R
+++ b/R/generics.R
@@ -1283,7 +1283,7 @@ Project <- function(object, ...) {
 #'
 #' @concept spatialimage
 #'
-Radius <- function(object) {
+Radius <- function(object, ...) {
   UseMethod(generic = 'Radius', object = object)
 }
 

--- a/R/spatial.R
+++ b/R/spatial.R
@@ -257,7 +257,7 @@ Key.SpatialImage <- function(object, ...) {
 #' @method Radius SpatialImage
 #' @export
 #'
-Radius.SpatialImage <- function(object) {
+Radius.SpatialImage <- function(object, ...) {
   return(NULL)
 }
 

--- a/man/Centroids-methods.Rd
+++ b/man/Centroids-methods.Rd
@@ -21,7 +21,7 @@
 
 \method{GetTissueCoordinates}{Centroids}(object, full = TRUE, ...)
 
-\method{Radius}{Centroids}(object)
+\method{Radius}{Centroids}(object, ...)
 
 \method{RenameCells}{Centroids}(object, new.names = NULL, ...)
 

--- a/man/Radius.Rd
+++ b/man/Radius.Rd
@@ -4,7 +4,7 @@
 \alias{Radius}
 \title{Get the spot radius from an image}
 \usage{
-Radius(object)
+Radius(object, ...)
 }
 \arguments{
 \item{object}{An image object}

--- a/man/SpatialImage-methods.Rd
+++ b/man/SpatialImage-methods.Rd
@@ -34,7 +34,7 @@
 
 \method{Key}{SpatialImage}(object, ...) <- value
 
-\method{Radius}{SpatialImage}(object)
+\method{Radius}{SpatialImage}(object, ...)
 
 \method{RenameCells}{SpatialImage}(object, new.names = NULL, ...)
 


### PR DESCRIPTION
Enables concrete implementations of `Radius` to take in parameters by adding `...` to the generic's signature. Adding a `scale` parameter to `Radius.VisiumV1` defined in `Seurat` would help to enable users to plot with the "tissue_hires_image.png" from Visium datasets. 

