### PR TITLE
Cleanup initialize definition for FOV

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.1.9005
+Version: 5.0.1.9006
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/R/fov.R
+++ b/R/fov.R
@@ -904,13 +904,8 @@ setMethod(
 setMethod(
   f = 'initialize',
   signature = 'FOV',
-  definition = function(.Object, molecules, boundaries, assay, key, ...) {
+  definition = function(.Object, ...) {
     .Object <- callNextMethod(.Object, ...)
-    slot(object = .Object, name = 'molecules') <- molecules
-    slot(object = .Object, name = 'boundaries') <- boundaries
-    slot(object = .Object, name = 'assay') <- assay
-    slot(object = .Object, name = 'key') <- key
-    # Reorder cells in boundaries
     .Object <- .OrderCells(object = .Object)
     validObject(object = .Object)
     return(.Object)


### PR DESCRIPTION
I'm like 82% sure this isn't the right way to do this but I haven't been able to get things working the way I'd like them to. Pushing this up mostly to give us something concrete to talk about 😬 

That said, I'd like to have the forthcoming `VisiumV2` inherit from `FOV` so that it works with both `SpatialPlot` _and_ `ImageFeaturePlot`/`ImageDimPlot` and `BuildNicheAssay` (i.e. plays nice with `sp`). This actually works really well except for one, not insignificant hiccup, the way things are implemented now, any time I try to initialize a class that inherits ("contains") `FOV` I get the following error thrown somewhere in the call stack:

```
Error in .nextMethod(.Object, ...) : argument is missing, with no default
```

Since I still don't have a fantastic understanding of the way R handles method dispatch and inheritance so there's a good chance I've hit a common pitfall here. The change I have pushed resolves the error and doesn't seem to have any negative side effects, as far as I'm able to tell. 

I'm defining `VisiumV2` like so:

```R
#' @name VisiumV2-class
#' @exportClass VisiumV2
VisiumV2 <- setClass(
  Class = "VisiumV2",
  contains = "FOV",
  slots = list(
    image = "array",
    scale.factors = "scalefactors"
  )
)
```

I see the error whether or not I define an `initialize` method for `VisiumV2`. I've tried a bunch of different definitions but none seem to be able to avoid the error getting thrown, even if they do not explicitly invoke `callNextMethod`. As far as I've been able to riddle out, R seems to be making multiple calls to `initialize.FOV` and somewhere along the line none of the parameters are being passed in - I'd guess this has something to do with the way `...` is handled down the call stack. 

I appreciate any suggestions you can give me 🙏 Thanks in advance

