### PR TITLE
Bug fix in `PolyVtx()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.1.9006
+Version: 5.0.1.9007
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - Class key-based warnings (#180)
 - Require R 4.1 (#180)
 - Fix errors in `UpdateSeuratObject` (@ddiez, #182)
+- Fix bug in `PolyVtx` (#194)
 
 # SeuratObject 5.0.1
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1391,8 +1391,7 @@ PackageCheck <- function(..., error = TRUE) {
 #' @references \url{https://stackoverflow.com/questions/3436453/calculate-coordinates-of-a-regular-polygons-vertices}
 #'
 #' @examples
-#' coords <- PolyVtx(5, t1 = 90)
-#' coords
+#' (coords <- PolyVtx(5, t1 = 90))
 #' if (requireNamespace("ggplot2", quietly = TRUE)) {
 #'   ggplot2::ggplot(coords, ggplot2::aes(x = x, y = y)) + ggplot2::geom_polygon()
 #' }
@@ -1403,10 +1402,16 @@ PolyVtx <- function(n, r = 1L, xc = 0L, yc = 0L, t1 = 0) {
   } else if (n < 3L) {
     abort(message = "'n' must be greater than or equal to 3")
   }
-  stopifnot(is_bare_integerish(x = r, n = 1L, finite = TRUE))
-  stopifnot(is_bare_integerish(x = xc, n = 1L, finite = TRUE))
-  stopifnot(is_bare_integerish(x = yc, n = 1L, finite = TRUE))
-  stopifnot(is_bare_numeric(x = t1, n = 1L))
+  stopifnot(
+    "'r' must be a single, finite number" = is_bare_numeric(x = r, n = 1L) &&
+      is.finite(x = r),
+    "'xc' must be a single, finite number" = is_bare_numeric(x = xc, n = 1L) &&
+      is.finite(x = xc),
+    "'yc' must be a single, finite number" = is_bare_numeric(x = yc, n = 1L) &&
+      is.finite(x = yc),
+    "'t1' must be a single, finite number" = is_bare_numeric(x = t1, n = 1L) &&
+      is.finite(x = t1)
+  )
   t1 <- Radians(deg = t1)
   coords <- matrix(data = 0, nrow = n, ncol = 2)
   colnames(x = coords) <- c('x', 'y')

--- a/man/PolyVtx.Rd
+++ b/man/PolyVtx.Rd
@@ -28,8 +28,7 @@ its radius (distance from center to vertex). Also permits transforming the
 resulting coordinates by moving the origin and altering the initial angle
 }
 \examples{
-coords <- PolyVtx(5, t1 = 90)
-coords
+(coords <- PolyVtx(5, t1 = 90))
 if (requireNamespace("ggplot2", quietly = TRUE)) {
   ggplot2::ggplot(coords, ggplot2::aes(x = x, y = y)) + ggplot2::geom_polygon()
 }


### PR DESCRIPTION
Allow `r` (radius), `xc` (x center), and `yc` (y center) to be numeric instead of integers; also simplify example for `PolyVtx()`