### PR TITLE
Use `packageVersion("SeuratObject")` in `UpdateSeuratObject()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.1.9008
+Version: 5.0.1.9009
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,11 @@
 # Unreleased
 
 ## Changes:
-- Add `...` to call signature for `Radius` generic
 - Properly re-export `%||%` from rlang (#178)
 - Class key-based warnings (#180)
 - Require R 4.1 (#180)
 - Fix errors in `UpdateSeuratObject` (@ddiez, #182)
+- Add `...` to call signature for `Radius` generic (#190)
 - Fix bug in `PolyVtx` (#194)
 - Fix bug in feature-level subsetting (#200)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - Add `...` to call signature for `Radius` generic (#190)
 - Fix bug in `PolyVtx` (#194)
 - Fix bug in feature-level subsetting (#200)
+- Update `UpdateSeuratObject` to run without `Seurat` installed (#199)
 
 # SeuratObject 5.0.1
 

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -1104,7 +1104,7 @@ UpdateSeuratObject <- function(object) {
         )
       }
       # Update object version
-      slot(object = object, name = 'version') <- packageVersion(pkg = 'Seurat')
+      slot(object = object, name = 'version') <- packageVersion(pkg = 'SeuratObject')
     }
     object <- suppressWarnings(
       expr = UpdateSlots(object = object),


### PR DESCRIPTION
Use the package version of SeuratObject instead of Seurat in `UpdateSeuratObject()`; this allows running `UpdateSeuratObject()` without requiring Seurat to be installed