### PR TITLE
Subsetting feature-level metadata fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.1.9007
+Version: 5.0.1.9008
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 - Require R 4.1 (#180)
 - Fix errors in `UpdateSeuratObject` (@ddiez, #182)
 - Fix bug in `PolyVtx` (#194)
-- Fix bug in feature-level subsetting
+- Fix bug in feature-level subsetting (#200)
 
 # SeuratObject 5.0.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - Require R 4.1 (#180)
 - Fix errors in `UpdateSeuratObject` (@ddiez, #182)
 - Fix bug in `PolyVtx` (#194)
+- Fix bug in feature-level subsetting
 
 # SeuratObject 5.0.1
 

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -2411,6 +2411,12 @@ subset.StdAssay <- function(
   for (lyr in setdiff(x = layers.all, y = layers)) {
     LayerData(object = x, layer = lyr) <- NULL
   }
+  # Subset feature-level metadata
+  mfeatures <- MatchCells(
+    new = Features(x = x, layer = NA),
+    orig = features,
+    ordered = TRUE
+  )
   # Perform the subsets
   for (l in layers) {
     lcells <- MatchCells(
@@ -2442,12 +2448,6 @@ subset.StdAssay <- function(
   for (i in c('cells', 'features')) {
     slot(object = x, name = i) <- droplevels(x = slot(object = x, name = i))
   }
-  # Subset feature-level metadata
-  mfeatures <- MatchCells(
-    new = Features(x = x, layer = NA),
-    orig = features,
-    ordered = TRUE
-  )
   slot(object = x, name = 'meta.data') <- slot(
     object = x,
     name = 'meta.data'


### PR DESCRIPTION
Subsetting features like so `pbmc3k_subset <- subset(pbmc3k, features = features)` was not correctly subsetting the feature-level metadata resulting in different variable features in the subsetted object. The code that subsetted the feature-level metadata was running after the features of the object had already been subset, so the new and original features were the same and thus instead of removing the features in place, they were removed from the end of the table. 

Explained in more detail here: https://github.com/satijalab/project-management/issues/73
