### PR TITLE
Make CellsByIdentities into S3 generic

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -375,6 +375,27 @@ Cells <- function(x, ...) {
   UseMethod(generic = 'Cells', object = x)
 }
 
+#' Get cell names grouped by identity class
+#'
+#' @template param-dots-method
+#' @param object An object
+#'
+#' @return A named list where names are identity classes and values are vectors
+#' of cells belonging to that class
+#'
+#' @rdname CellsByIdentities
+#' @export CellsByIdentities
+#'
+#' @concept data-access
+#' @family dimnames
+#'
+#' @examples
+#' CellsByIdentities(x = pbmc_small)
+#'
+CellsByIdentities <- function(object, ...) {
+  UseMethod(generic = 'CellsByIdentities', object = object)
+}
+
 #' Check Matrix Validity
 #'
 #' @template param-dots-method

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -154,7 +154,6 @@ setClass(
 
 #' Get cell names grouped by identity class
 #'
-#' @param object A Seurat object
 #' @param idents A vector of identity class levels to limit resulting list to;
 #' defaults to all identity class levels
 #' @param cells A vector of cells to grouping to
@@ -164,14 +163,17 @@ setClass(
 #' @return A named list where names are identity classes and values are vectors
 #' of cells belonging to that class
 #'
+#' @rdname CellsByIdentities
 #' @export
+#' @method CellsByIdentities Seurat
 #'
 #' @concept data-access
 #'
 #' @examples
 #' CellsByIdentities(object = pbmc_small)
 #'
-CellsByIdentities <- function(
+
+CellsByIdentities.Seurat <- function(
   object,
   idents = NULL,
   cells = NULL,

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -160,9 +160,6 @@ setClass(
 #' @param return.null If no cells are requested, return a \code{NULL};
 #' by default, throws an error
 #'
-#' @return A named list where names are identity classes and values are vectors
-#' of cells belonging to that class
-#'
 #' @rdname CellsByIdentities
 #' @export
 #' @method CellsByIdentities Seurat


### PR DESCRIPTION
Hi Seurat Team,

This PR is definitely something optional and totally fine if rejected.  Recently, I have been updating scCustomize to work with new version of liger which has substantial improvements.  It's been wonderful that SeuratObject has so many data access functions as S3 generics (`Cells`, `Features`, `WhichCells`, etc) because I can easily reexport them and extend them to function with liger objects in seamless manner so that same function works with both Seurat and liger objects.

One function, that I recently wrote version for liger, which would be great to have as generic is `CellsByIdentities`.  I realize this doesn't fit use cases of most other generics in SeuratObject because it's only designed to work with full objects and Assay or other classes.

For this PR:  
- I updated the generics.R script copying format of other generics.
- I updated seurat.R `CellsByIdentities` again following formats used for other generics.
- I tried to make changes with littlest noise possible so that it doesn't have inadvertent downstream effects for function within Seurat and I don't think these changes should cause issue elsewhere in code.

Again, totally realize this may either not be priority or not something that you want to change and that's all good and I can implement liger version with different function name if so.

Thanks!
Sam