### PR TITLE
Fix/image subset

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.1.9010
+Version: 5.0.1.9011
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - Fix bug in feature-level subsetting (#200)
 - Update `UpdateSeuratObject` to run without `Seurat` installed (#199)
 - Add warning in `Layers.Assay()` when the search returns no results (@maxim-h, #189)
+- Fix bug in `subset` to allow empty images to be dropped (#204)
 
 # SeuratObject 5.0.1
 

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -3787,7 +3787,13 @@ subset.Seurat <- function(
  #  }
   # subset images
   for (image in Images(object = x)) {
-    x[[image]] <- base::subset(x = x[[image]], cells = cells)
+    cells.from.image <- cells[cells %in% Cells(x[[image]])]
+    if (length(cells.from.image) == 0) {
+      image.subset <- NULL
+    } else {
+      image.subset <- base::subset(x = x[[image]], cells = cells.from.image)
+    }
+    x[[image]] <- image.subset
   }
   return(x)
 }


### PR DESCRIPTION
This PR addresses a bug in the way `subset.Seurat` handles images - for more details see:
- https://github.com/satijalab/project-management/issues/79

Introducing a more robust test suite is on the horizon for `SeuratObject` starting with ... - since it's already on the docket I'll skip tests for now. Instead, the following snippets should provide a sufficient sanity check:

```R
library(testthat)

library(Seurat)
library(SeuratData)


brain_anterior =  LoadData("stxBrain", type = "anterior1")
brain_posterior =  LoadData("stxBrain", type = "posterior1")
brain <- merge(brain_posterior, brain_anterior)

result <- subset(brain, cells = Cells(brain[["anterior1"]]))

expect_equal(length(Images(result)), 1)
```

```R
library(Seurat)


path_to_visium_hd <- "/Users/dcollins/workspace/data/visium-hd_human_colon_cancer"
visium_hd <- Load10X_Spatial(path_to_visium_hd)

subset(visium_hd, cells = Cells(visium_hd[["slice1.016um"]]))
```