### PR TITLE
Move on-disk layers path-by-path rather than layer-by-layer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.2
+Version: 5.0.2.9001
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -758,23 +758,29 @@ SaveSeuratRds <- function(
       next
     }
     if (isTRUE(x = move)) {
-      for (i in seq_len(length.out = nrow(x = df))) {
-        pth <- df$path[i]
+      df.split <- split(x = df, f = df$path)
+      for (i in seq_along(along.with = df.split)) {
+        pth <- names(x = df.split)[i]
         p(
           message = paste(
-            "Moving layer",
-            sQuote(x = df$layer[i]),
-            "to",
-            sQuote(x = destdir)
+            strwrap(x = paste(
+              "Moving on-disk layer at",
+              sQuote(x = pth),
+              "to",
+              sQuote(x = destdir)
+            )),
+            collapse = '\n'
           ),
           class = 'sticky',
           amount = 0
         )
-        df[i, 'path'] <- as.character(x = .FileMove(
+        df.split[[i]]$path <- as.character(x = .FileMove(
           path = pth,
           new_path = destdir
         ))
       }
+      df <- do.call(what = rbind, args = df.split)
+      row.names(x = df) <- NULL
     }
     if (isTRUE(x = relative)) {
       p(


### PR DESCRIPTION
It's possible for multiple layers to work off of the same disk-backed objects; in these cases, moving one layer causes moving the other layers to fail as their disk-backed representation no longer exists. This PR adjusts `SaveSeuratRds()` to move on-disk layers path-by-path rather than layer-by-layer