### PR TITLE
Fix md.features and data.features comparison

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SeuratObject
 Title: Data Structures for Single Cell Data
-Version: 5.0.99.9015
+Version: 5.0.99.9016
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Changes:
+- Fix bug in `UpdateSeuratObject` (@neanderthalensis, #210)
 - Fix bug in `WhichCells.Seurat` (@maxim-h, #219)
 - Update `subset.Seurat` to call `droplevels` on the input's cell-level `meta.data` slot; update `subset.Assay` to call `droplevels` on the input's feature-level `meta.features` slot; update `subset.StdAssay` to call `droplevels` on the input's feature-level `meta.data` slot (#251)
 - Update `UpdateSeuratObject` to call `droplevels` on the input's cell-level `meta.data` slot (@samuel-marsh, #247)

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -994,7 +994,7 @@ UpdateSeuratObject <- function(object) {
         sd.features <- rownames(x = slot(object = assay, name = "scale.data"))
         data.features <- rownames(x = slot(object = assay, name = "data"))
         md.features <- rownames(x = slot(object = assay, name = "meta.features"))
-        if (!all.equal(target = md.features, current = data.features, check.attributes = FALSE)) {
+        if (!identical(md.features, data.features)) {
           slot(object = assay, name = "meta.features") <- slot(object = assay, name = "meta.features")[data.features, ]
         }
         sd.order <- sd.features[order(match(x = sd.features, table = data.features))]


### PR DESCRIPTION
When trying to run UpdateSeuratObject on this [dataset](https://figshare.com/articles/dataset/Expression_of_97_surface_markers_and_462_mRNAs_in_70017_cells_from_healthy_young_healthy_old_and_leukemic_human_bone_marrow/13397651) I got the following error message:  `Error in !all.equal(target = md.features, current = data.features, check.attributes = FALSE) : 
  invalid argument type`

`all.equal` returns true if `md.features` and `data.features` are indeed identical. However in case where the two vectors differ it returns a character vector of length two describing the mismatch. For the RNA slot in the above dataset it returns: 

```
[1] "Lengths (463, 461) differ (string compare on first 461)"
[2] "8 string mismatches" 
```
The proposed change simply replaces `all.equal()` with `identical()` which should be more suitable as it will simply determine if the two vectors are identical and returns a boolean which can then be used by the if statement.
