### PR TITLE
Return variable features directly if you have set them yourself

### DIFF
--- a/R/assay5.R
+++ b/R/assay5.R
@@ -1553,9 +1553,7 @@ VariableFeatures.StdAssay <- function(
       var.features <- as.vector(object["var.features", drop = TRUE])
       var.features <- var.features[!is.na(var.features)]
     }
-    if (isTRUE(x = simplify) & (is.null(x = layer) || any(is.na(x = layer))) &
-        (is.infinite(x = nfeatures) || length(x = var.features) ==
-         nfeatures)) {
+    if (isTRUE(x = simplify) & (is.null(x = layer) || any(is.na(x = layer)))) {
       return(var.features)
     }
   }


### PR DESCRIPTION
This has a corresponding fix in seurat-private: [PR](https://github.com/satijalab/seurat-private/pull/924). s/o @longmanz for identifying and helping fix this issue. 


The issue occurred when we tried to pull out `VariableFeatures` from an object in which we first ran `FindVariableFeatures()`, and then set our own `VariableFeatures` after. If we tried to pull out the re-set variable features, it pulled out the features previously calculated with `FindVariableFeatures` before

```
pbmc3k_v2 = FindVariableFeatures(pbmc3k)
VariableFeatures(pbmc3k_v2) <- rownames(pbmc3k_v2)[1:100]
head(pbmc3k_v2[["RNA"]]@meta.data)
# won't return the ones you've set 
head(VariableFeatures(pbmc3k_v2[["RNA"]], nfeatures = 2000))
```
The issue was that we have a check that we skip to the calculated variable features if nfeatures != Inf or the # of variable features. The solution is to almost always return the variable features directly if you have set them yourself. 

Documented more here: https://github.com/orgs/satijalab/projects/1/views/1?pane=issue&itemId=51523433