### PR TITLE
Fix/subset stdassay

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.99.9000
+Version: 5.0.99.9001
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Changes:
+- Fix bug in `subset` - prevent `invalid 'row.names' length` error when one or more layers are dropped during feature-level subsetting (#214)
+
 # SeuratObject 5.0.2
 
 ## Changes:

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -2395,7 +2395,8 @@ subset.StdAssay <- function(
   if (is.numeric(x = features)) {
     features <- Features(x = x, layer = NA)[features]
   }
-  features <- intersect(x = features, y = Features(x = x, layer = NA))
+  all_features <- Features(x = x, layer = NA)
+  features <- intersect(x = features, y = all_features)
   if (!length(x = features)) {
     stop("None of the features provided found in this assay", call. = FALSE)
   }
@@ -2411,12 +2412,6 @@ subset.StdAssay <- function(
   for (lyr in setdiff(x = layers.all, y = layers)) {
     LayerData(object = x, layer = lyr) <- NULL
   }
-  # Subset feature-level metadata
-  mfeatures <- MatchCells(
-    new = Features(x = x, layer = NA),
-    orig = features,
-    ordered = TRUE
-  )
   # Perform the subsets
   for (l in layers) {
     lcells <- MatchCells(
@@ -2448,6 +2443,13 @@ subset.StdAssay <- function(
   for (i in c('cells', 'features')) {
     slot(object = x, name = i) <- droplevels(x = slot(object = x, name = i))
   }
+  # Subset feature-level metadata
+  mfeatures <- MatchCells(
+    new = all_features,
+    # in case any features were found in a only one layer and it was dropped
+    orig = intersect(features, Features(x = x, layer = NA)),
+    ordered = TRUE
+  )
   slot(object = x, name = 'meta.data') <- slot(
     object = x,
     name = 'meta.data'

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -2360,7 +2360,7 @@ subset.StdAssay <- function(
   layers = NULL,
   ...
 ) {
-  if (is.null(x = cells) && is.null(x = features)) {
+  if (is.null(cells) && is.null(features) && is.null(layers)){
     return(x)
   }
   # Check the cells vector


### PR DESCRIPTION
Resolves:
- https://github.com/satijalab/seurat/issues/8916

The issue was introduced in:
- https://github.com/satijalab/seurat-object/pull/200

Which was in turn resolving an issue with the way the feature-level metadata was being incorrectly handled.

When calling `MatchCells` to subset the feature level metadata, we need to make sure that:
1. `orig` contains all of the feature names that were originally in `x`
2. `new` contains _only_ feature names that are still in the layers of `x` 

Our first fix took care of the first point but failed to properly address the second, causing the following error if any features were being lost in the process of subsetting out the layers:

```
Error in .rowNamesDF<-(x, value = value) : invalid 'row.names' length
```