### PR TITLE
Add basic CI checks 

### DIFF
--- a/.github/workflows/integration_checks.yaml
+++ b/.github/workflows/integration_checks.yaml
@@ -43,3 +43,10 @@ jobs:
       # case the `rcmdcheck` output will be uploaded as an artifact
       - name: Run Checks
         uses: r-lib/actions/check-r-package@v2
+        env:
+          # suppress NOTEs that are accepted by CRAN
+          # see: https://www.rdocumentation.org/packages/rcmdcheck/versions/1.4.0/topics/rcmdcheck
+          _R_CHECK_PKG_SIZES_: false
+          _R_CHECK_RD_XREFS_: false
+          _R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_: false
+          _R_CHECK_PACKAGE_DATASETS_SUPPRESS_NOTES_: true

--- a/.github/workflows/integration_checks.yaml
+++ b/.github/workflows/integration_checks.yaml
@@ -1,0 +1,45 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+name: Integration Checks
+
+# because `main` is a protected branch this workflow is triggered when a PR 
+# is opened/updated and again when it is merged
+on:
+  push:
+    branches: 
+    - main
+  pull_request:
+    branches: 
+    - main
+
+jobs:
+  check-package:
+    runs-on: ubuntu-latest
+
+    steps:
+      # pull the latest changes from the repository down to the runner
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # install R-release and any system dependencies
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          # specify additional repositories to pull dependencies not
+          # available on CRAN (i.e. `BPCells`)
+          extra-repositories: ${{ 'https://bnprks.r-universe.dev' }}
+      
+      # install R dependencies
+      - name: Install Dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: 
+            any::rcmdcheck
+          # installed packages are cached by default - force an upgrade to the 
+          # latest version of all dependencies
+          upgrade: 'TRUE'
+      
+      # run CRAN checks - fails if any ERRORs or WARNINGs are raised in which 
+      # case the `rcmdcheck` output will be uploaded as an artifact
+      - name: Run Checks
+        uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/integration_checks.yaml
+++ b/.github/workflows/integration_checks.yaml
@@ -35,6 +35,7 @@ jobs:
         with:
           extra-packages: 
             any::rcmdcheck
+            any::pkgdown
           # installed packages are cached by default - force an upgrade to the 
           # latest version of all dependencies
           upgrade: 'TRUE'
@@ -44,9 +45,19 @@ jobs:
       - name: Run Checks
         uses: r-lib/actions/check-r-package@v2
         env:
-          # suppress NOTEs that are accepted by CRAN
-          # see: https://www.rdocumentation.org/packages/rcmdcheck/versions/1.4.0/topics/rcmdcheck
-          _R_CHECK_PKG_SIZES_: false
-          _R_CHECK_RD_XREFS_: false
-          _R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_: false
-          _R_CHECK_PACKAGE_DATASETS_SUPPRESS_NOTES_: true
+            # suppress NOTEs that are accepted by CRAN
+            # see: https://www.rdocumentation.org/packages/rcmdcheck/versions/1.4.0/topics/rcmdcheck
+            _R_CHECK_PKG_SIZES_: false
+            _R_CHECK_RD_XREFS_: false
+            _R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_: false
+            _R_CHECK_PACKAGE_DATASETS_SUPPRESS_NOTES_: true
+        continue-on-error: true
+      
+      # build pkgdown site
+      - name: Build Website
+        run: | 
+          pkgdown::build_site_github_pages(
+            new_process = FALSE, 
+            install = FALSE
+          )
+        shell: Rscript {0}

--- a/.github/workflows/integration_checks.yaml
+++ b/.github/workflows/integration_checks.yaml
@@ -14,17 +14,28 @@ on:
 
 jobs:
   check-package:
+    # system dependencies for cannot be automatically resolved by 
+    # `r-lib/actions/setup-r@v2` for macos or windows - to avoid having to 
+    # maintain separate logic to infer and install system of those operating 
+    # systems we'll only run integration checks with the ubuntu
     runs-on: ubuntu-latest
+
+    # run integration checks with R-release, R-devel, and R-oldrelease
+    strategy:
+      matrix:
+        r-version: ['release', 'devel', 'oldrel']
 
     steps:
       # pull the latest changes from the repository down to the runner
       - name: Checkout
         uses: actions/checkout@v4
 
-      # install R-release and any system dependencies
+      # install R and any system dependencies
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
+          # install the R version specified by the current strategy
+          r-version: ${{ matrix.r-version }}
           # specify additional repositories to pull dependencies not
           # available on CRAN (i.e. `BPCells`)
           extra-repositories: ${{ 'https://bnprks.r-universe.dev' }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.2
+Version: 5.0.99.9000
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),


### PR DESCRIPTION
This PR introduces basic CI checks for `SeuratObject`. The `Integration Checks` workflow will run on every PR and push to `main`. The action leans heavily on [r-lib/actions](https://github.com/r-lib/actions) to:
- Install R and all system dependencies required by the package
- Install (and cache) all R dependencies
- Runs CRAN checks with `rcmdcheck`
- Checks that the `pkgdown` site can be built successfully

