### PR TITLE
Allow feature/varialble name to be next to `)`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SeuratObject
 Title: Data Structures for Single Cell Data
-Version: 5.0.99.9014
+Version: 5.0.99.9015
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Changes:
+- Fix bug in `WhichCells.Seurat` (@maxim-h, #219)
 - Update `subset.Seurat` to call `droplevels` on the input's cell-level `meta.data` slot; update `subset.Assay` to call `droplevels` on the input's feature-level `meta.features` slot; update `subset.StdAssay` to call `droplevels` on the input's feature-level `meta.data` slot (#251)
 - Update `UpdateSeuratObject` to call `droplevels` on the input's cell-level `meta.data` slot (@samuel-marsh, #247)
 - Drop `Seurat` from `Enhances`; update `.IsFutureSeurat` to avoid calling `requireNamespace('Seurat', ...)` (#250)

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -2825,6 +2825,12 @@ WhichCells.Seurat <- function(
       fixed = TRUE
     )
     expr.char <- gsub(
+      pattern = ')',
+      replacement = '',
+      x = expr.char,
+      fixed = TRUE
+    )
+    expr.char <- gsub(
       pattern = '`',
       replacement = '',
       x = expr.char

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -2816,25 +2816,7 @@ WhichCells.Seurat <- function(
     } else {
       parse(text = expression)
     }
-    expr.char <- suppressWarnings(expr = as.character(x = expr))
-    expr.char <- unlist(x = lapply(X = expr.char, FUN = strsplit, split = ' '))
-    expr.char <- gsub(
-      pattern = '(',
-      replacement = '',
-      x = expr.char,
-      fixed = TRUE
-    )
-    expr.char <- gsub(
-      pattern = ')',
-      replacement = '',
-      x = expr.char,
-      fixed = TRUE
-    )
-    expr.char <- gsub(
-      pattern = '`',
-      replacement = '',
-      x = expr.char
-    )
+    expr.char <- all.vars(expr)
     vars.use <- which(
       x = expr.char %in% rownames(x = object) |
         expr.char %in% colnames(x = object[[]]) |


### PR DESCRIPTION
I've always had problems when using some more involved patterns with `subset.Seurat`, e.g.:

```r
> subset(seurat, subset = !grepl("cycling", celltype))
Error in `FetchData()`:
! None of the requested variables were found: 
Run `rlang::last_trace()` to see where the error occurred.
```

Turns out the `WhichCells` strips the opening bracket, but not the closing one, when searching for feature/variable names in `expression`. 

I've fixed the issue for myself with this small change, but not sure if this was on purpose and my change breaks something else.