### PR TITLE
add calcN parameter to CreateSeuratObject

### DIFF
--- a/R/seurat.R
+++ b/R/seurat.R
@@ -1247,6 +1247,7 @@ CreateSeuratObject.default <- function(
   project = 'SeuratProject',
   min.cells = 0,
   min.features = 0,
+  calcN = NULL,
   ...
 ) {
   assay.version <- getOption(x = 'Seurat.object.assay.version', default = 'v5')
@@ -1279,7 +1280,8 @@ CreateSeuratObject.default <- function(
     names.field = names.field,
     names.delim = names.delim,
     meta.data = meta.data,
-    project = project
+    project = project,
+    calcN = calcN,
   ))
 }
 
@@ -1294,6 +1296,7 @@ CreateSeuratObject.Assay <- function(
   names.delim = '_',
   meta.data = NULL,
   project = 'SeuratProject',
+  calcN = NULL,
   ...
 ) {
   # Check the assay key
@@ -1348,11 +1351,11 @@ CreateSeuratObject.Assay <- function(
   options(op)
   object[['orig.ident']] <- idents
   # Calculate nCount and nFeature
-  calcN_option <- getOption(
+  # Check for user-provided calcN_option; if not provided, get the global option or default to TRUE
+  calcN_option <- calcN %||% getOption(
     x = 'Seurat.object.assay.calcn',
-    default =  Seurat.options$Seurat.object.assay.calcn
-  )
-  calcN_option <- calcN_option %||% TRUE
+    default = Seurat.options$Seurat.object.assay.calcn
+  ) %||% TRUE
   if (isTRUE(x = calcN_option)) {
     ncalc <- CalcN(object = counts)
     if (!is.null(x = ncalc)) {


### PR DESCRIPTION
I'm not 100% sure that we want to do this, but I am playing around with adding a `calcN` parameter to `CreateSeuratObject` to enable disabling/enabling the calculation of `nCounts` and `nFeatures` without overriding the global option. This would be cleaner for internal functions to enable specific behavior without having to carefully set/return global options. 

If we want to do this, I'll write documentation and tests for this parameter. 


```R
devtools::load_all("~/data/github/seurat-object/")
devtools::load_all("~/data/github/seurat/")

getOption("Seurat.object.assay.calcn")

#global option is set to null by default
obj <- CreateSeuratObject(pbmc_small[['RNA']]$counts, 
                          calcN=FALSE)
grep("nCount_RNA", colnames(obj[[]]))
obj <- CreateSeuratObject(pbmc_small[['RNA']]$counts, 
                          calcN=TRUE)
grep("nCount_RNA", colnames(obj[[]]))
obj <- CreateSeuratObject(pbmc_small[['RNA']]$counts)
grep("nCount_RNA", colnames(obj[[]]))

#set global default but override if set in function call
options("Seurat.object.assay.calcn" = FALSE)
obj <- CreateSeuratObject(pbmc_small[['RNA']]$counts)
grep("nCount_RNA", colnames(obj[[]]))
obj <- CreateSeuratObject(pbmc_small[['RNA']]$counts, 
                          calcN=TRUE)
grep("nCount_RNA", colnames(obj[[]]))
```