### PR TITLE
Update integration checks to use satijalab/seurat-ci Docker image

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,6 +20,5 @@
 ^.*\.Rds$
 ^data-raw$
 ^inst$
-^tests$
 ^LICENSE\.md$
 ^vignettes/articles$

--- a/.github/workflows/integration_checks.yaml
+++ b/.github/workflows/integration_checks.yaml
@@ -1,9 +1,7 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 name: Integration Checks
 
-# because `main` is a protected branch this workflow is triggered when a PR 
-# is opened/updated and again when it is merged
+# Because `main` is a protected branch this workflow is triggered when a PR 
+# is opened/updated and again when it is merged.
 on:
   push:
     branches: 
@@ -14,60 +12,33 @@ on:
 
 jobs:
   check-package:
-    # system dependencies for cannot be automatically resolved by 
-    # `r-lib/actions/setup-r@v2` for macos or windows - to avoid having to 
-    # maintain separate logic to infer and install system of those operating 
-    # systems we'll only run integration checks with the ubuntu
     runs-on: ubuntu-latest
-
-    # run integration checks with R-release, R-devel, and R-oldrelease
-    strategy:
-      matrix:
-        r-version: ['release', 'devel', 'oldrel']
+    
+    # Use the `satijalab/seurat-ci` Docker image as the runner environment. 
+    # This image is pre-configured with everything required for running
+    # integration checks, for more details, see
+    # https://hub.docker.com/repository/docker/satijalab/seurat-ci/general.
+    container:
+      image: satijalab/seurat-ci:latest
 
     steps:
-      # pull the latest changes from the repository down to the runner
+      # Pull the latest changes from the repository down to the runner.
       - name: Checkout
         uses: actions/checkout@v4
-
-      # install R and any system dependencies
-      - name: Setup R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          # install the R version specified by the current strategy
-          r-version: ${{ matrix.r-version }}
-          # rspm provides pre-compiles binary packages, providing faster
-          # more reliable installs
-          use-public-rspm: true
-          # specify additional repositories to pull dependencies not
-          # available on CRAN (i.e. `BPCells`)
-          extra-repositories: ${{ 'https://bnprks.r-universe.dev' }}
       
-      # install R dependencies
+      # Install the package and all its dependencies using scripts from 
+      # `littler`, see https://eddelbuettel.github.io/littler/ for details. 
+      # `Seurat` is listed under "Enhances" so it also needs to be installed. 
       - name: Install Dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: 
-            any::rcmdcheck
-            any::pkgdown
-          # installed packages are cached by default - force an upgrade to the 
-          # latest version of all dependencies
-          upgrade: 'TRUE'
+        run: installDeps.r -s && install.r Seurat
       
-      # run CRAN checks - fails if any ERRORs or WARNINGs are raised in which 
-      # case the `rcmdcheck` output will be uploaded as an artifact
+      # Run CRAN checks, if any ERRORs or WARNINGs are raised the check fails.
       - name: Run Checks
-        uses: r-lib/actions/check-r-package@v2
-        env:
-            # suppress NOTEs that are accepted by CRAN
-            # see: https://www.rdocumentation.org/packages/rcmdcheck/versions/1.4.0/topics/rcmdcheck
-            _R_CHECK_PKG_SIZES_: false
-            _R_CHECK_RD_XREFS_: false
-            _R_CHECK_CRAN_INCOMING_NOTE_GNU_MAKE_: false
-            _R_CHECK_PACKAGE_DATASETS_SUPPRESS_NOTES_: true
+        run: rcmdcheck::rcmdcheck(args = "--as-cran", error_on="warning")
+        shell: Rscript {0}
         continue-on-error: true
       
-      # build pkgdown site
+      # Build the pkgdown site.
       - name: Build Website
         run: | 
           pkgdown::build_site_github_pages(

--- a/.github/workflows/integration_checks.yaml
+++ b/.github/workflows/integration_checks.yaml
@@ -36,6 +36,9 @@ jobs:
         with:
           # install the R version specified by the current strategy
           r-version: ${{ matrix.r-version }}
+          # rspm provides pre-compiles binary packages, providing faster
+          # more reliable installs
+          use-public-rspm: true
           # specify additional repositories to pull dependencies not
           # available on CRAN (i.e. `BPCells`)
           extra-repositories: ${{ 'https://bnprks.r-universe.dev' }}

--- a/.github/workflows/integration_checks.yaml
+++ b/.github/workflows/integration_checks.yaml
@@ -38,7 +38,7 @@ jobs:
         shell: Rscript {0}
         continue-on-error: true
       
-      # Build the pkgdown site.
+      # Build the `pkgdown` site, if any errors are raised the check fails.
       - name: Build Website
         run: | 
           pkgdown::build_site_github_pages(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.99.9001
+Version: 5.0.99.9002
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,4 @@
 library(testthat)
-library(Seurat)
+library(SeuratObject)
 
-test_check("Seurat")
+test_check("SeuratObject")


### PR DESCRIPTION
Picking up where https://github.com/satijalab/seurat-object/pull/217 left off, this PR introduces two key improvements to the Integration Checks workflow:

1. Enables tests to be run via `R CMD check` by dropping the /tests directory from `.Rbuildignore` and then updating /test/testthat.R file to run the tests for `SeuratObject` rather than `Seurat` (not sure if this was intentional or not). Until now, `R CMD check` and `rcmdcheck::rcmdcheck` by extension have never been running `SeuratObject`’s tests, including during CRAN’s reverse dependency checks. 

2. Updates the workflow to use the `satijalab/seurat-ci` Docker image as its runner environment, eliminating the need for the [r-lib/actions](https://github.com/r-lib/actions) we were previously using and (critically) speeding up the workflow.

The initial implementation of the Integration Checks workflow was taking ~55 minutes to run, owing mostly to dependency installation. Since the `satijalab/seurat-ci` image uses `rocker/r2u` as its base, package installation is very fast and the workflow now takes a little under 5 minutes to run 🚀 Another option to speed up dependency installation would be to use `rspm` which is provided as a built-in option for `r-lib/actions/setup-r@v2` like we do [here](https://github.com/satijalab/seurat-object/blob/42e53ba4324c6714616d2635c746bbbb823bb730/.github/workflows/pkgdown.yaml#L27). This would have reduced the workflow runtime down to ~20 minutes. For the sake of posterity, I’ve included that change as b486bd5 so that implementation can always be recycled later. 

Transitioning to a Docker-based action has the handy side-effect of introducing a portable testing environment that developers can use locally 🤘(more on this soon). The only real downside is that the r2u project only supports `R-release` so we're no longer able to run checks with `R-oldrelease` or `R-devel`.

This should probably wait for https://github.com/satijalab/seurat-docker/pull/4 before being merged 😬

**tl;dr: Updates the Integration Checks workflow, delivering an 11x speedup.** 

