### PR TITLE
Fix/build manual

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,6 +69,7 @@ Suggests:
 LinkingTo: Rcpp, RcppEigen
 Enhances: Seurat
 Config/Needs/website: pkgdown
+BuildManual: true
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,4 @@
 Package: SeuratObject
-Type: Package
 Title: Data Structures for Single Cell Data
 Version: 5.0.99.9003
 Authors@R: c(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SeuratObject
 Title: Data Structures for Single Cell Data
-Version: 5.0.99.9003
+Version: 5.0.99.9004
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,19 +44,19 @@ Depends:
 Imports:
   future,
   future.apply,
+  generics,
   grDevices,
   grid,
+  lifecycle,
   Matrix (>= 1.6.4),
   methods,
   progressr,
   Rcpp (>= 1.0.5),
   rlang (>= 0.4.7),
+  spam,
   stats,
   tools,
-  utils,
-  spam,
-  lifecycle,
-  generics
+  utils
 Suggests:
   DelayedArray,
   fs (>= 1.5.2),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,14 +58,14 @@ Imports:
   tools,
   utils
 Suggests:
+  BPCells,
   DelayedArray,
   fs (>= 1.5.2),
   ggplot2,
   HDF5Array,
   rmarkdown,
-  testthat,
-  BPCells,
-  sf (>= 1.0.0)
+  sf (>= 1.0.0),
+  testthat
 LinkingTo: Rcpp, RcppEigen
 Enhances: Seurat
 Config/Needs/website: pkgdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,8 @@ Authors@R: c(
   person(given = 'Christoph', family = 'Hafemeister', email = 'chafemeister@nygenome.org', role = 'ctb', comment = c(ORCID = '0000-0001-6365-8254')),
   person(given = 'Patrick', family = 'Roelli', email = 'proelli@nygenome.org', role = 'ctb')
   )
-Description: Defines S4 classes for single-cell genomic data and associated
+Description: 
+  Defines S4 classes for single-cell genomic data and associated
   information, such as dimensionality reduction embeddings, nearest-neighbor
   graphs, and spatially-resolved coordinates. Provides data access methods and
   R-native hooks to ensure the Seurat object is familiar to other R users. See
@@ -29,70 +30,70 @@ Description: Defines S4 classes for single-cell genomic data and associated
   Hao Y, Hao S, et al (2021) <doi:10.1016/j.cell.2021.04.048> and
   Hao Y, et al (2023) <doi:10.1101/2022.02.24.481684> for
   more details.
-URL: https://satijalab.github.io/seurat-object/,
-    https://github.com/satijalab/seurat-object
-BugReports: https://github.com/satijalab/seurat-object/issues
 License: MIT + file LICENSE
+URL: 
+  https://satijalab.github.io/seurat-object/,
+  https://github.com/satijalab/seurat-object
+BugReports: 
+  https://github.com/satijalab/seurat-object/issues
+Additional_repositories: 
+  https://bnprks.r-universe.dev
+Depends:
+  R (>= 4.1.0),
+  sp (>= 1.5.0)
+Imports:
+  future,
+  future.apply,
+  grDevices,
+  grid,
+  Matrix (>= 1.6.4),
+  methods,
+  progressr,
+  Rcpp (>= 1.0.5),
+  rlang (>= 0.4.7),
+  stats,
+  tools,
+  utils,
+  spam,
+  lifecycle,
+  generics
+Suggests:
+  DelayedArray,
+  fs (>= 1.5.2),
+  ggplot2,
+  HDF5Array,
+  rmarkdown,
+  testthat,
+  BPCells,
+  sf (>= 1.0.0)
+LinkingTo: Rcpp, RcppEigen
+Enhances: Seurat
+Config/Needs/website: pkgdown
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.1
-Additional_repositories:
-    https://bnprks.r-universe.dev
-Depends:
-    R (>= 4.1.0),
-    sp (>= 1.5.0)
-Imports:
-    future,
-    future.apply,
-    grDevices,
-    grid,
-    Matrix (>= 1.6.4),
-    methods,
-    progressr,
-    Rcpp (>= 1.0.5),
-    rlang (>= 0.4.7),
-    stats,
-    tools,
-    utils,
-    spam,
-    lifecycle,
-    generics
-Suggests:
-    DelayedArray,
-    fs (>= 1.5.2),
-    ggplot2,
-    HDF5Array,
-    rmarkdown,
-    testthat,
-    BPCells,
-    sf (>= 1.0.0)
 Collate:
-    'RcppExports.R'
-    'zzz.R'
-    'generics.R'
-    'keymixin.R'
-    'graph.R'
-    'default.R'
-    'assay.R'
-    'logmap.R'
-    'layers.R'
-    'assay5.R'
-    'centroids.R'
-    'command.R'
-    'compliance.R'
-    'data.R'
-    'jackstraw.R'
-    'dimreduc.R'
-    'segmentation.R'
-    'molecules.R'
-    'spatial.R'
-    'fov.R'
-    'neighbor.R'
-    'seurat.R'
-    'sparse.R'
-    'utils.R'
-LinkingTo: Rcpp, RcppEigen
-Enhances:
-    Seurat
-Config/Needs/website:
-    pkgdown
+  'RcppExports.R'
+  'zzz.R'
+  'generics.R'
+  'keymixin.R'
+  'graph.R'
+  'default.R'
+  'assay.R'
+  'logmap.R'
+  'layers.R'
+  'assay5.R'
+  'centroids.R'
+  'command.R'
+  'compliance.R'
+  'data.R'
+  'jackstraw.R'
+  'dimreduc.R'
+  'segmentation.R'
+  'molecules.R'
+  'spatial.R'
+  'fov.R'
+  'neighbor.R'
+  'seurat.R'
+  'sparse.R'
+  'utils.R'


### PR DESCRIPTION
This PR applies some housekeeping changes to the package's DESCRIPTION file. Critically, the "BuildManual" field is added and set to `true`.

As far as I have been able to suss out, as of R v4.3.2, `R CMD build` requires the `BuildManual` field to be `true` in order for the package's PDF manual to be generated, even if there are install-time or render-time `/Sexpr` macros are present in the package's man/*.Rd files. Currently, the following NOTE is being thrown by CRAN checks (the last line is the problematic one):

```
❯ checking CRAN incoming feasibility ... [6s/19s] NOTE
  Maintainer: ‘Rahul Satija <seurat@nygenome.org>’
  
  Version contains large components (5.0.99.9003)
  
  Suggests or Enhances not in mainstream repositories:
    BPCells
  Availability using Additional_repositories specification:
    BPCells   yes   https://bnprks.r-universe.dev/
  
  Package has help file(s) containing install/render-stage \Sexpr{} expressions but no prebuilt PDF manual.
  ```

I first encountered [this issue](https://github.com/satijalab/seurat-object/pull/205#issuecomment-2098407411) while cutting the release for `SeuratObject` v5.0.2 but [attributed it to a problem with my local environment](https://github.com/satijalab/seurat-object/pull/205#issuecomment-2098685720). Upon digging deeper, I noticed that the [successful build](https://github.com/satijalab/seurat-object/pull/205#issuecomment-2098702870) used R v4.2.2 and was eventually able to pinpoint the issue to [this](https://github.com/wch/r-source/commit/94ddaee81e43bc24964f544ef2b5ee85b4fc4930) change in the R source code, which updated the default value for the "BuildManual" field from `TRUE` to `FALSE` 🕵️ 

Curiously, CRAN's [documentation](https://cran.r-project.org/doc/manuals/R-exts.html#Building-package-tarballs-1) on writing R extensions appears to describe the old behavior 🤷 

The only other non-cosmetic change introduced in this PR is that the "Type" field was dropped from the package's DESCRIPTION—this field defaults to "Package" and can only take one other value ("Frontend"). The main motivation for dropping it is for consistency with `Seurat` 🤓 
