### PR TITLE
Stop R patch update triggering 'reinstall SeuratObject'

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -507,7 +507,11 @@ NameIndex <- function(x, names, MARGIN) {
 .onAttach <- function(libname, pkgname) {
   for (i in names(x = .BuiltWith)) {
     current <- switch(EXPR = i, R = getRversion(), packageVersion(pkg = i))
-    if (current > .BuiltWith[i]) {
+    # Compare major and minor versions only, not patch
+    curr_parts <- as.numeric(unlist(strsplit(as.character(current), "\\.")))
+    built_parts <- as.numeric(unlist(strsplit(as.character(.BuiltWith[i]), "\\.")))
+    if (curr_parts[1] > built_parts[1] || 
+        (curr_parts[1] == built_parts[1] && curr_parts[2] > built_parts[2])) {
       msg <- paste(
         sQuote(x = pkgname),
         "was built",


### PR DESCRIPTION
I performed a patch update of my R install from 4.3.0 to 4.3.3. According to the official R documentation I have read, this should not require reinstalling any R packages, but when loading SeuratObject I see:

```
> library(Seurat)
Attaching SeuratObject
‘SeuratObject’ was built under R 4.3.0 but the current version is
4.3.3; it is recomended that you reinstall ‘SeuratObject’ as the ABI
for R may have changed
```

This PR focuses version check on major and minor, ignore patch.