### PR TITLE
Fix the behavior of the getter of VariableFeatures and how 'nfeatures =' behaves

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SeuratObject
 Title: Data Structures for Single Cell Data
-Version: 5.0.99.9004
+Version: 5.0.99.9007
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.99.9001
+Version: 5.0.99.9007
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.99.9000
+Version: 5.0.99.9001
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -1545,19 +1545,23 @@ VariableFeatures.StdAssay <- function(
   }
   nfeatures <- nfeatures %||% Inf
   if ("var.features" %in% colnames(object[[]])) {
-    if ("var.features.rank" %in% colnames(object[[]])) {
-      var.features <- row.names(x = object[[]])[which(!is.na(object[[]]$var.features.rank))]
-      var.features <- var.features[order(object[[]][["var.features.rank"]][which(!is.na(object[[]]$var.features))])]
-    }
-    else {
-      var.features <- as.vector(object["var.features", drop = TRUE])
-      var.features <- var.features[!is.na(var.features)]
-    }
-    if (isTRUE(x = simplify) & (is.null(x = layer) || any(is.na(x = layer))) &
-        (is.infinite(x = nfeatures) || length(x = var.features) ==
-         nfeatures)) {
-      return(var.features)
-    }
+      if ("var.features.rank" %in% colnames(object[[]])) {
+          var.features <- row.names(x = object[[]])[which(!is.na(object[[]]$var.features.rank))]
+          var.features <- var.features[order(object[[]][["var.features.rank"]][which(!is.na(object[[]]$var.features))])]
+      }
+      else {
+          var.features <- as.vector(object["var.features", drop = TRUE])
+          var.features <- var.features[!is.na(var.features)]
+      }
+      if (isTRUE(x = simplify) & (is.null(x = layer) || any(is.na(x = layer))) &
+          (is.infinite(x = nfeatures) || length(x = var.features) <=
+           nfeatures)) {
+          return(var.features) 
+      } else if (isTRUE(x = simplify) & (is.null(x = layer) || any(is.na(x = layer))) &
+                 (is.infinite(x = nfeatures) || length(x = var.features) >
+                  nfeatures)) {
+          return(var.features[1:nfeatures])
+      }
   }
   msg <- 'No variable features found'
   layer.orig <- layer


### PR DESCRIPTION
This is a fix (with help from @Gesmira and @dcollins15 ) building on:
- https://github.com/satijalab/seurat-object/pull/213

Basically, the `VariableFeatures()` getter is re-written (using the solution provided in post 2 above) and now it respects its setter. With the this PR, users can correctly set and reset the `VariableFeatures()` (i.e., with a vector of gene names) **before** and **after** they run `FindVariableFeatures()`. The getter will now correctly return the user-defined variable features. Previously, it will return the wrong variable features (calculated by the `FindVariableFeatures()` if that has been run), as reported in post 3.

In addition, now the getter also respects the `'nfeatures = n'` flag. If `nfeatures` is set to a number smaller than the length of the existing variable features, it will output the top `nfeatures` genes, while if it is set to a number larger than the length of the existing variable features, it will output the complete list. Previously, for user-defined variable features (without running FindVariableFeatures() prior), the getter will automatically return all the VariableFeatures even when `nfeatures =` is set. 