### PR TITLE
 Fix `subset` to properly update the features `LogMap` for `StdAssay` inputs when subsetting by metadata

### DIFF
--- a/R/assay5.R
+++ b/R/assay5.R
@@ -2432,15 +2432,18 @@ subset.StdAssay <- function(
     # if no valid cells or features, drop the layer data
     if (is.null(layer_cells) || is.null(layer_features)) {
       LayerData(object = x, layer = layer_name) <- NULL
+      # TODO: change default layer
       next
-    } 
-    # otherwise, apply the subset
-    LayerData(object = x, layer = layer_name) <- LayerData(
-      object = x,
-      layer = layer_name,
-      cells = layer_cells,
-      features = layer_features
-    )
+    }
+    else {
+      # otherwise, apply the subset
+      LayerData(object = x, layer = layer_name) <- LayerData(
+        object = x,
+        layer = layer_name,
+        cells = layer_cells,
+        features = layer_features
+      )
+    }
   }
 
   # clean up the cells and features slots


### PR DESCRIPTION
Aims to resolve:
- https://github.com/satijalab/seurat/issues/9001

The issue seems to arise when:

1. The subset operation is inadvertently dropping an entire layer
2. The layer being dropped contains features that are not present in any others.

This explains why users were able to safely subset their objects after running NormalizeData.

The solution is to ensure that the two calls to `LayerData` on lines [2434 and 2438 of assay5.R](https://github.com/satijalab/seurat-object/blob/85ce3002487ec041a2309d6f5dbea50d9ed7d403/R/assay5.R#L2432-L2444) are mutually exclusive. In lieu of a proper test, the following script can be used to verify the fix:

```R
library(testthat)
library(Seurat)
library(SeuratData)

pbmc <- LoadData("pbmc3k")
ifnb <- LoadData("ifnb")

left <- AddMetaData(
  pbmc, 
  metadata = runif(nrow(pbmc), min = 8, max = 9), 
  col.name = "test_val"
)

right <- AddMetaData(
  ifnb, 
  metadata = runif(nrow(ifnb), min = 9, max = 10), 
  col.name = "test_val"
)

merged <- merge(left, right)

expect_no_error(subset(merged, subset = test_val >= 9))
```
