### PR TITLE
Fix Integration Checks workflow to fail when CRAN checks do

### DIFF
--- a/.github/workflows/integration_checks.yaml
+++ b/.github/workflows/integration_checks.yaml
@@ -36,10 +36,11 @@ jobs:
       - name: Run Checks
         run: rcmdcheck::rcmdcheck(args = "--as-cran", error_on="warning")
         shell: Rscript {0}
-        continue-on-error: true
       
       # Build the `pkgdown` site, if any errors are raised the check fails.
       - name: Build Website
+        # Run this step even if the previous one failed.
+        if: always()
         run: | 
           pkgdown::build_site_github_pages(
             new_process = FALSE, 

--- a/tests/testthat/test_logmap.R
+++ b/tests/testthat/test_logmap.R
@@ -63,5 +63,5 @@ test_that("`labels` generic works as expected for `LogMap` instances", {
   expect_identical(result_key, result)
 
   # If no labels are found, an error is raised.
-  expect_no_error(labels(map, "value_5"))
+  expect_error(labels(map, "value_5"))
 })

--- a/tests/testthat/test_logmap.R
+++ b/tests/testthat/test_logmap.R
@@ -63,5 +63,5 @@ test_that("`labels` generic works as expected for `LogMap` instances", {
   expect_identical(result_key, result)
 
   # If no labels are found, an error is raised.
-  expect_error(labels(map, "value_5"))
+  expect_no_error(labels(map, "value_5"))
 })


### PR DESCRIPTION
This PR makes a small adjustment to the Integration Checks [workflow](https://github.com/satijalab/seurat-object/actions/workflows/integration_checks.yaml) so that it fails if the `Run Checks` step of the `check-package` job does. 

In the current configuration, this line prevents the workflow from failing when the step does. The intent was to make sure that the subsequent `Build Website` step was always run. Instead of using `continue-on-error: true` with `Run Checks` we can add `if: always()` to `Build Website` 👍 