### PR TITLE
Fix HVFInfo.StdAssay

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -72,7 +72,7 @@ Config/Needs/website: pkgdown
 BuildManual: true
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Collate:
   'RcppExports.R'
   'zzz.R'

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -970,7 +970,7 @@ GetAssayData.StdAssay <- function(
 #'
 HVFInfo.StdAssay <- function(
   object,
-  method,
+  method = NULL,
   status = FALSE,
   layer = NA,
   strip = TRUE,
@@ -978,6 +978,12 @@ HVFInfo.StdAssay <- function(
 ) {
   # Create a named list mapping HVF methods to the layers they're available for.
   layers_by_method <- .VFMethodsLayers(object, layers = layer, type = "hvf")
+
+  # If `method` is not provided, use the last one from `layer_by_method`.
+  if (is.null(method)) {
+    available_methods <- names(layers_by_method)
+    method <- available_methods[length(available_methods)]
+  }
 
   # If method is not set, take the last from the available set.
   method <- switch(

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -972,7 +972,7 @@ HVFInfo.StdAssay <- function(
   object,
   method,
   status = FALSE,
-  layer = NULL,
+  layer = NA,
   strip = TRUE,
   ...
 ) {

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -992,7 +992,10 @@ HVFInfo.StdAssay <- function(
   if (!method %in% names(layers_by_method)) {
     stop(
       sprintf(
-        "Unable to find highly variable feature information for method '%s'.",
+        paste(
+          "Unable to find highly variable feature information for ",
+          "method='%s' and layer='%s'."
+        ),
         method, 
         layer
       )

--- a/man/VariableFeatures-StdAssay.Rd
+++ b/man/VariableFeatures-StdAssay.Rd
@@ -7,7 +7,7 @@
 \alias{VariableFeatures<-.StdAssay}
 \title{Highly Variable Features}
 \usage{
-\method{HVFInfo}{StdAssay}(object, method = NULL, status = FALSE, layer = NULL, strip = TRUE, ...)
+\method{HVFInfo}{StdAssay}(object, method = NULL, status = FALSE, layer = NA, strip = TRUE, ...)
 
 \method{VariableFeatures}{StdAssay}(
   object,

--- a/man/VariableFeatures.Rd
+++ b/man/VariableFeatures.Rd
@@ -93,7 +93,7 @@ SpatiallyVariableFeatures(object, method, ...)
 
 \method{VariableFeatures}{Assay}(object, ...) <- value
 
-\method{HVFInfo}{Assay5}(object, method = NULL, status = FALSE, layer = NULL, strip = TRUE, ...)
+\method{HVFInfo}{Assay5}(object, method = NULL, status = FALSE, layer = NA, strip = TRUE, ...)
 
 \method{VariableFeatures}{Assay5}(
   object,

--- a/tests/testthat/test_assay5.R
+++ b/tests/testthat/test_assay5.R
@@ -1,0 +1,23 @@
+#' Returns a random counts matrix.
+get_test_assay <- function(ncells, nfeatures, assay_version) {
+  # Use the `assay_version` param to choose the correct assay builder.
+  create_assay <- switch(assay_version,
+                         v3 = CreateAssayObject,
+                         v5 = CreateAssay5Object,
+                         stop("`assay_version` should be one of 'v3', 'v5'")
+  )
+  
+  # Populate a `nfeatures` x `ncells` matrix with zeros.
+  counts <- matrix(0, ncol = ncells, nrow = nfeatures)
+  
+  # Assign column and row names to the matrix to label cells and genes.
+  colnames(counts) <- paste0("cell", seq(ncol(counts)))
+  row.names(counts) <- paste0("gene", seq(nrow(counts)))
+  
+  # Convert `counts` to a `dgCMatrix`.
+  counts_sparse <- as.sparse(counts)
+  # Build an assay of the specified type.
+  assay <- create_assay(counts_sparse)
+  
+  return(assay)
+}

--- a/tests/testthat/test_assay5.R
+++ b/tests/testthat/test_assay5.R
@@ -165,11 +165,11 @@ test_that("`HVFInfo.Assay5` works with multiple methods run on different layers"
   expect_identical(result, mvp_info["value"])
 
   # Check that `layer` can be omitted. In this case, `layer` will default to
-  # `NULL` which will be in turn be interpreted as `DefaultLayer(assay)`.
-  # Thus, we are expected `layer` to resolve to "counts".
+  # `NA` which will be in turn be interpreted as `Layers(assay)` (i.e. all layers).
   result <- HVFInfo(assay, method = "vst")
   expect_identical(result, vst_info["value"])
-  expect_error(HVFInfo(assay, method = "mvp"))
+  result <- HVFInfo(assay, method = "mvp")
+  expect_identical(result, mvp_info["value"])
 
   # Check that `layer` can be `NULL`. In this case, `layer` will be interpreted
   # as `DefaultLayer(assay)`. Thus, we are expected `layer` to resolve to "counts".
@@ -239,10 +239,10 @@ test_that("`HVFInfo.Assay5` works with a single method run on multiple layers", 
   expect_identical(result, vst.2_info["value"])
 
   # Check that `layer` can be omitted. In this case, `layer` will default to
-  # `NULL` which will be in turn be interpreted as `DefaultLayer(assay)`.
-  # Thus, we are expected `layer` to resolve to "counts.1".
+  # `NULL` which will be in turn be interpreted as `Layers(assay)` 
+  # (i.e. all layers). Thus, we are expected `layer` to resolve to "counts.2".
   result <- HVFInfo(assay, method = "vst")
-  expect_identical(result, vst.1_info["value"])
+  expect_identical(result, vst.2_info["value"])
 
   # Check that `layer` can be `NULL`. In this case, `layer` will be interpreted
   # as `DefaultLayer(assay)`. Thus, we are expected `layer` to resolve to "counts".

--- a/tests/testthat/test_assay5.R
+++ b/tests/testthat/test_assay5.R
@@ -21,3 +21,44 @@ get_test_assay <- function(ncells, nfeatures, assay_version) {
   
   return(assay)
 }
+
+#' Mocks "highly variable feature" annotations and adds them to the 
+#' feature-level metadata of `assay`.
+add_hvf_info <- function(assay, nfeatures, method_name, layer_name) {
+  variable_features <- sample(
+    rownames(assay), 
+    size = nfeatures, 
+    replace = FALSE
+  )
+
+  all_features <- rownames(assay)
+  constant_features <- setdiff(all_features, variable_features)
+  
+  # Add a column to the assay's feature-level metadata indicating which
+  # features are variable.
+  is_variable <- all_features %in% variable_features
+  names(is_variable) <- all_features
+  variable_column <- paste("vf", method_name, layer_name, "variable", sep = "_")
+  assay[[variable_column]] <- is_variable
+  
+  # Add a column to the assay's feature-level metadata indicating the order
+  # (i.e. "rank") that each variable feature was selected in.
+  variable_rank <- seq_along(variable_features)
+  names(variable_rank) <- variable_features
+  constant_rank <- seq_along(constant_features) + length(variable_features)
+  names(constant_rank) <- constant_features
+  feature_rank <- c(variable_rank, constant_rank)
+  rank_column <- paste("vf", method_name, layer_name, "rank", sep = "_")
+  assay[[rank_column]] <- feature_rank
+
+  # Add a column to the assay's feature-level metadata containing a random
+  # values in reverse order from `variable_rank` (i.e. the lowest rank
+  # has the highest value).
+  feature_values <- runif(length(all_features))
+  feature_values <- sort(feature_values, decreasing = TRUE)
+  names(feature_values) <- names(feature_rank)
+  value_column <- paste("vf", method_name, layer_name, "value", sep = "_")
+  assay[[value_column]] <- feature_values
+  
+  return(assay)
+}

--- a/tests/testthat/test_assay5.R
+++ b/tests/testthat/test_assay5.R
@@ -62,3 +62,69 @@ add_hvf_info <- function(assay, nfeatures, method_name, layer_name) {
   
   return(assay)
 }
+
+context("HVFInfo")
+
+test_that("`HVFInfo.Assay5` works with a single set of metadata", {
+  # Populate an assay with random values for testing.
+  assay <- get_test_assay(
+    ncells = 10,
+    nfeatures = 10,
+    assay_version = "v5"
+  )
+  # Add similarly random HVF metadata to `assay`.
+  assay <- add_hvf_info(
+    assay, 
+    nfeatures = 10,
+    method_name = "vst", 
+    layer_name = "counts"
+  )
+
+  # Extract the expected HVFInfo and rename the columns.
+  info_columns <- c(
+    "vf_vst_counts_variable", 
+    "vf_vst_counts_rank", 
+    "vf_vst_counts_value"
+  )
+  expected_info <- assay[[]][, info_columns]
+  colnames(expected_info) <- c("variable", "rank", "value")
+
+  # Check the base case where `method` and `layer` are both set and valid.
+  result <- HVFInfo(assay, method = "vst", layer = "counts")
+  expect_identical(result, expected_info["value"])
+
+  # Check the same case with all relevant HVF columns returned.
+  result <- HVFInfo(assay, method = "vst", layer = "counts", status = TRUE)
+  expect_identical(result, expected_info)
+
+  # Check that `layer` can be omitted.
+  result <- HVFInfo(assay, method = "vst")
+  expect_identical(result, expected_info["value"])
+
+  # Check the same case with all relevant HVF columns returned.
+  result <- HVFInfo(assay, method = "vst", status = TRUE)
+  expect_identical(result, expected_info)
+
+  # Check that `layer` can be `NULL`.
+  result <- HVFInfo(assay, method = "vst", layer = NULL)
+  expect_identical(result, expected_info["value"])
+
+  # Check the same case with all relevant HVF columns returned.
+  result <- HVFInfo(assay, method = "vst", layer = NULL, status = TRUE)
+  expect_identical(result, expected_info)
+
+  # Check that `layer` can be `NA`.
+  result <- HVFInfo(assay, method = "vst", layer = NA)
+  expect_identical(result, expected_info["value"])
+
+  # Check the same case with all relevant HVF columns returned.
+  result <- HVFInfo(assay, method = "vst", layer = NA, status = TRUE)
+  expect_identical(result, expected_info)
+
+  # Check that the `method` parameter must be provided.
+  expect_error(HVFInfo(assay))
+  expect_error(HVFInfo(assay, layer = "counts"))
+
+  # Check that `method` must point to HVF metadata.
+  expect_error(HVFInfo(assay, method = "not-a-method"))
+})

--- a/tests/testthat/test_assay5.R
+++ b/tests/testthat/test_assay5.R
@@ -307,3 +307,95 @@ test_that("`HVFInfo.Assay5` works with a single method run on multiple layers", 
   result <- HVFInfo(assay, method = "vst", layer = NA, status = TRUE)
   expect_identical(result, vst.2_info)
 })
+
+test_that("`HVFInfo.Assay5` works with multiple methods run on the same layer", {
+  # Populate an assay with random values for testing.
+  assay <- get_test_assay(
+    ncells = 10,
+    nfeatures = 10,
+    assay_version = "v5"
+  )
+  # Add similarly random HVF metadata to `assay`.
+  assay <- add_hvf_info(
+    assay, 
+    nfeatures = 5,
+    method_name = "vst", 
+    layer_name = "counts"
+  )
+  # Add a second set of HVF columns to `assay`.
+  assay <- add_hvf_info(
+    assay, 
+    nfeatures = 5,
+    method_name = "mvp", 
+    layer_name = "counts"
+  )
+
+  # Extract the first set of HVF info and rename the columns.
+  vst_columns <- c(
+    "vf_vst_counts_variable", 
+    "vf_vst_counts_rank", 
+    "vf_vst_counts_value"
+  )
+  vst_info <- assay[[]][, vst_columns]
+  colnames(vst_info) <- c("variable", "rank", "value")
+  # Extract the first set of HVF info and rename the columns.
+  mvp_columns <- c(
+    "vf_mvp_counts_variable", 
+    "vf_mvp_counts_rank", 
+    "vf_mvp_counts_value"
+  )
+  mvp_info <- assay[[]][, mvp_columns]
+  colnames(mvp_info) <- c("variable", "rank", "value")
+
+  # Check the base case where `method` and `layer` are both set and valid.
+  result <- HVFInfo(assay, method = "vst", layer = "counts")
+  expect_identical(result, vst_info["value"])
+  result <- HVFInfo(assay, method = "mvp", layer = "counts")
+  expect_identical(result, mvp_info["value"])
+
+  # Check the same case with all relevant HVF columns returned.
+  result <- HVFInfo(assay, method = "vst", layer = "counts", status = TRUE)
+  expect_identical(result, vst_info)
+  result <- HVFInfo(assay, method = "mvp", layer = "counts", status = TRUE)
+  expect_identical(result, mvp_info)
+
+  # Check that `layer` can be omitted. In this case, `layer` will default to
+  # `NULL` which will be in turn be interpreted as `DefaultLayer(assay)`. 
+  # Thus, we are expected `layer` to resolve to "counts".
+  result <- HVFInfo(assay, method = "vst")
+  expect_identical(result, vst_info["value"])
+  result <- HVFInfo(assay, method = "mvp")
+  expect_identical(result, mvp_info["value"])
+
+  # Check the same case with all relevant HVF columns returned.
+  result <- HVFInfo(assay, method = "vst", status = TRUE)
+  expect_identical(result, vst_info)
+  result <- HVFInfo(assay, method = "mvp", status = TRUE)
+  expect_identical(result, mvp_info)
+
+  # Check that `layer` can be `NULL`. In this case, `layer` will be interpreted 
+  # as `DefaultLayer(assay)`. Thus, we are expected `layer` to resolve to "counts".
+  result <- HVFInfo(assay, method = "vst", layer = NULL)
+  expect_identical(result, vst_info["value"])
+  result <- HVFInfo(assay, method = "mvp", layer = NULL)
+  expect_identical(result, mvp_info["value"])
+
+  # Check the same case with all relevant HVF columns returned.
+  result <- HVFInfo(assay, method = "vst", layer = NULL, status = TRUE)
+  expect_identical(result, vst_info)
+  result <- HVFInfo(assay, method = "mvp", layer = NULL, status = TRUE)
+  expect_identical(result, mvp_info)
+
+  # Check that `layer` can be `NA`. In this case, `layer` will be interpreted
+  # as `Layers(assay)` (i.e. all layers).
+  result <- HVFInfo(assay, method = "vst", layer = NA)
+  expect_identical(result, vst_info["value"])
+  result <- HVFInfo(assay, method = "mvp", layer = NA)
+  expect_identical(result, mvp_info["value"])
+
+  # Check the same case with all relevant HVF columns returned.
+  result <- HVFInfo(assay, method = "vst", layer = NA, status = TRUE)
+  expect_identical(result, vst_info)
+  result <- HVFInfo(assay, method = "mvp", layer = NA, status = TRUE)
+  expect_identical(result, mvp_info)
+})

--- a/tests/testthat/test_assay5.R
+++ b/tests/testthat/test_assay5.R
@@ -109,9 +109,9 @@ test_that("`HVFInfo.Assay5` works with a single set of metadata", {
   result <- HVFInfo(assay, method = "vst", layer = NA)
   expect_identical(result, expected_info["value"])
 
-  # Check that the `method` parameter must be provided.
-  expect_error(HVFInfo(assay))
-  expect_error(HVFInfo(assay, layer = "counts"))
+  # Check that the `method` parameter can be omitted.
+  result <- HVFInfo(assay)
+  expect_identical(result, expected_info["value"])
 
   # Check that `method` must point to HVF metadata.
   expect_error(HVFInfo(assay, method = "not-a-method"))

--- a/tests/testthat/test_assay5.R
+++ b/tests/testthat/test_assay5.R
@@ -101,25 +101,13 @@ test_that("`HVFInfo.Assay5` works with a single set of metadata", {
   result <- HVFInfo(assay, method = "vst")
   expect_identical(result, expected_info["value"])
 
-  # Check the same case with all relevant HVF columns returned.
-  result <- HVFInfo(assay, method = "vst", status = TRUE)
-  expect_identical(result, expected_info)
-
   # Check that `layer` can be `NULL`.
   result <- HVFInfo(assay, method = "vst", layer = NULL)
   expect_identical(result, expected_info["value"])
 
-  # Check the same case with all relevant HVF columns returned.
-  result <- HVFInfo(assay, method = "vst", layer = NULL, status = TRUE)
-  expect_identical(result, expected_info)
-
   # Check that `layer` can be `NA`.
   result <- HVFInfo(assay, method = "vst", layer = NA)
   expect_identical(result, expected_info["value"])
-
-  # Check the same case with all relevant HVF columns returned.
-  result <- HVFInfo(assay, method = "vst", layer = NA, status = TRUE)
-  expect_identical(result, expected_info)
 
   # Check that the `method` parameter must be provided.
   expect_error(HVFInfo(assay))
@@ -176,12 +164,6 @@ test_that("`HVFInfo.Assay5` works with multiple methods run on different layers"
   result <- HVFInfo(assay, method = "mvp", layer = "data")
   expect_identical(result, mvp_info["value"])
 
-  # Check the same case with all relevant HVF columns returned.
-  result <- HVFInfo(assay, method = "vst", layer = "counts", status = TRUE)
-  expect_identical(result, vst_info)
-  result <- HVFInfo(assay, method = "mvp", layer = "data", status = TRUE)
-  expect_identical(result, mvp_info)
-
   # Check that `layer` can be omitted. In this case, `layer` will default to
   # `NULL` which will be in turn be interpreted as `DefaultLayer(assay)`. 
   # Thus, we are expected `layer` to resolve to "counts".
@@ -189,21 +171,11 @@ test_that("`HVFInfo.Assay5` works with multiple methods run on different layers"
   expect_identical(result, vst_info["value"])
   expect_error(HVFInfo(assay, method = "mvp"))
 
-  # Check the same case with all relevant HVF columns returned.
-  result <- HVFInfo(assay, method = "vst", status = TRUE)
-  expect_identical(result, vst_info)
-  expect_error(HVFInfo(assay, method = "mvp", status = TRUE))
-
   # Check that `layer` can be `NULL`. In this case, `layer` will be interpreted 
   # as `DefaultLayer(assay)`. Thus, we are expected `layer` to resolve to "counts".
   result <- HVFInfo(assay, method = "vst", layer = NULL)
   expect_identical(result, vst_info["value"])
   expect_error(HVFInfo(assay, method = "mvp", layer = NULL))
-
-  # Check the same case with all relevant HVF columns returned.
-  result <- HVFInfo(assay, method = "vst", layer = NULL, status = TRUE)
-  expect_identical(result, vst_info)
-  expect_error(HVFInfo(assay, method = "mvp", layer = NULL, status = TRUE))
 
   # Check that `layer` can be `NA`. In this case, `layer` will be interpreted
   # as `Layers(assay)` (i.e. all layers).
@@ -211,12 +183,6 @@ test_that("`HVFInfo.Assay5` works with multiple methods run on different layers"
   expect_identical(result, vst_info["value"])
   result <- HVFInfo(assay, method = "mvp", layer = NA)
   expect_identical(result, mvp_info["value"])
-
-  # Check the same case with all relevant HVF columns returned.
-  result <- HVFInfo(assay, method = "vst", layer = NA, status = TRUE)
-  expect_identical(result, vst_info)
-  result <- HVFInfo(assay, method = "mvp", layer = NA, status = TRUE)
-  expect_identical(result, mvp_info)
 })
 
 test_that("`HVFInfo.Assay5` works with a single method run on multiple layers", {
@@ -272,40 +238,22 @@ test_that("`HVFInfo.Assay5` works with a single method run on multiple layers", 
   result <- HVFInfo(assay, method = "vst", layer = "counts.2")
   expect_identical(result, vst.2_info["value"])
 
-  # Check the same case with all relevant HVF columns returned.
-  result <- HVFInfo(assay, method = "vst", layer = "counts.1", status = TRUE)
-  expect_identical(result, vst.1_info)
-  result <- HVFInfo(assay, method = "vst", layer = "counts.2", status = TRUE)
-  expect_identical(result, vst.2_info)
-
   # Check that `layer` can be omitted. In this case, `layer` will default to
   # `NULL` which will be in turn be interpreted as `DefaultLayer(assay)`.
   # Thus, we are expected `layer` to resolve to "counts.1".
   result <- HVFInfo(assay, method = "vst")
   expect_identical(result, vst.1_info["value"])
 
-  # Check the same case with all relevant HVF columns returned.
-  result <- HVFInfo(assay, method = "vst", status = TRUE)
-  expect_identical(result, vst.1_info)
-
   # Check that `layer` can be `NULL`. In this case, `layer` will be interpreted 
   # as `DefaultLayer(assay)`. Thus, we are expected `layer` to resolve to "counts".
   result <- HVFInfo(assay, method = "vst", layer = NULL)
   expect_identical(result, vst.1_info["value"])
-
-  # Check the same case with all relevant HVF columns returned.
-  result <- HVFInfo(assay, method = "vst", layer = NULL, status = TRUE)
-  expect_identical(result, vst.1_info)
 
   # Check that `layer` can be `NA`. In this case, `layer` will be interpreted
   # as `Layers(assay)` (i.e. all layers) and the first one associated with 
   # `method` will be returned.
   result <- HVFInfo(assay, method = "vst", layer = NA)
   expect_identical(result, vst.2_info["value"])
-
-  # Check the same case with all relevant HVF columns returned.
-  result <- HVFInfo(assay, method = "vst", layer = NA, status = TRUE)
-  expect_identical(result, vst.2_info)
 })
 
 test_that("`HVFInfo.Assay5` works with multiple methods run on the same layer", {
@@ -367,12 +315,6 @@ test_that("`HVFInfo.Assay5` works with multiple methods run on the same layer", 
   result <- HVFInfo(assay, method = "mvp")
   expect_identical(result, mvp_info["value"])
 
-  # Check the same case with all relevant HVF columns returned.
-  result <- HVFInfo(assay, method = "vst", status = TRUE)
-  expect_identical(result, vst_info)
-  result <- HVFInfo(assay, method = "mvp", status = TRUE)
-  expect_identical(result, mvp_info)
-
   # Check that `layer` can be `NULL`. In this case, `layer` will be interpreted 
   # as `DefaultLayer(assay)`. Thus, we are expected `layer` to resolve to "counts".
   result <- HVFInfo(assay, method = "vst", layer = NULL)
@@ -380,22 +322,10 @@ test_that("`HVFInfo.Assay5` works with multiple methods run on the same layer", 
   result <- HVFInfo(assay, method = "mvp", layer = NULL)
   expect_identical(result, mvp_info["value"])
 
-  # Check the same case with all relevant HVF columns returned.
-  result <- HVFInfo(assay, method = "vst", layer = NULL, status = TRUE)
-  expect_identical(result, vst_info)
-  result <- HVFInfo(assay, method = "mvp", layer = NULL, status = TRUE)
-  expect_identical(result, mvp_info)
-
   # Check that `layer` can be `NA`. In this case, `layer` will be interpreted
   # as `Layers(assay)` (i.e. all layers).
   result <- HVFInfo(assay, method = "vst", layer = NA)
   expect_identical(result, vst_info["value"])
   result <- HVFInfo(assay, method = "mvp", layer = NA)
   expect_identical(result, mvp_info["value"])
-
-  # Check the same case with all relevant HVF columns returned.
-  result <- HVFInfo(assay, method = "vst", layer = NA, status = TRUE)
-  expect_identical(result, vst_info)
-  result <- HVFInfo(assay, method = "mvp", layer = NA, status = TRUE)
-  expect_identical(result, mvp_info)
 })

--- a/tests/testthat/test_assay5.R
+++ b/tests/testthat/test_assay5.R
@@ -128,3 +128,93 @@ test_that("`HVFInfo.Assay5` works with a single set of metadata", {
   # Check that `method` must point to HVF metadata.
   expect_error(HVFInfo(assay, method = "not-a-method"))
 })
+
+test_that("`HVFInfo.Assay5` works with multiple methods run on different layers", {
+  # Populate an assay with random values for testing.
+  assay <- get_test_assay(
+    ncells = 10,
+    nfeatures = 10,
+    assay_version = "v5"
+  )
+  # Add similarly random HVF metadata to `assay`.
+  assay <- add_hvf_info(
+    assay, 
+    nfeatures = 5,
+    method_name = "vst", 
+    layer_name = "counts"
+  )
+  # Add a second "data" layer to the assay by duplicating "count".
+  LayerData(assay, layer = "data") <- LayerData(assay, layer = "counts")
+  # Add a second set of HVF columns to `assay`.
+  assay <- add_hvf_info(
+    assay, 
+    nfeatures = 5,
+    method_name = "mvp", 
+    layer_name = "data"
+  )
+
+  # Extract the first set of HVF info and rename the columns.
+  vst_columns <- c(
+    "vf_vst_counts_variable", 
+    "vf_vst_counts_rank", 
+    "vf_vst_counts_value"
+  )
+  vst_info <- assay[[]][, vst_columns]
+  colnames(vst_info) <- c("variable", "rank", "value")
+  # Extract the first set of HVF info and rename the columns.
+  mvp_columns <- c(
+    "vf_mvp_data_variable", 
+    "vf_mvp_data_rank", 
+    "vf_mvp_data_value"
+  )
+  mvp_info <- assay[[]][, mvp_columns]
+  colnames(mvp_info) <- c("variable", "rank", "value")
+
+  # Check the base case where `method` and `layer` are both set and valid.
+  result <- HVFInfo(assay, method = "vst", layer = "counts")
+  expect_identical(result, vst_info["value"])
+  result <- HVFInfo(assay, method = "mvp", layer = "data")
+  expect_identical(result, mvp_info["value"])
+
+  # Check the same case with all relevant HVF columns returned.
+  result <- HVFInfo(assay, method = "vst", layer = "counts", status = TRUE)
+  expect_identical(result, vst_info)
+  result <- HVFInfo(assay, method = "mvp", layer = "data", status = TRUE)
+  expect_identical(result, mvp_info)
+
+  # Check that `layer` can be omitted. In this case, `layer` will default to
+  # `NULL` which will be in turn be interpreted as `DefaultLayer(assay)`. 
+  # Thus, we are expected `layer` to resolve to "counts".
+  result <- HVFInfo(assay, method = "vst")
+  expect_identical(result, vst_info["value"])
+  expect_error(HVFInfo(assay, method = "mvp"))
+
+  # Check the same case with all relevant HVF columns returned.
+  result <- HVFInfo(assay, method = "vst", status = TRUE)
+  expect_identical(result, vst_info)
+  expect_error(HVFInfo(assay, method = "mvp", status = TRUE))
+
+  # Check that `layer` can be `NULL`. In this case, `layer` will be interpreted 
+  # as `DefaultLayer(assay)`. Thus, we are expected `layer` to resolve to "counts".
+  result <- HVFInfo(assay, method = "vst", layer = NULL)
+  expect_identical(result, vst_info["value"])
+  expect_error(HVFInfo(assay, method = "mvp", layer = NULL))
+
+  # Check the same case with all relevant HVF columns returned.
+  result <- HVFInfo(assay, method = "vst", layer = NULL, status = TRUE)
+  expect_identical(result, vst_info)
+  expect_error(HVFInfo(assay, method = "mvp", layer = NULL, status = TRUE))
+
+  # Check that `layer` can be `NA`. In this case, `layer` will be interpreted
+  # as `Layers(assay)` (i.e. all layers).
+  result <- HVFInfo(assay, method = "vst", layer = NA)
+  expect_identical(result, vst_info["value"])
+  result <- HVFInfo(assay, method = "mvp", layer = NA)
+  expect_identical(result, mvp_info["value"])
+
+  # Check the same case with all relevant HVF columns returned.
+  result <- HVFInfo(assay, method = "vst", layer = NA, status = TRUE)
+  expect_identical(result, vst_info)
+  result <- HVFInfo(assay, method = "mvp", layer = NA, status = TRUE)
+  expect_identical(result, mvp_info)
+})


### PR DESCRIPTION
This PR fixes `HVFInfo.StdAssay` when `method` is specified but `layer` is not. This PR also introduces a comprehensive set of tests for the method. 

This PR was motivated by the following issue with `Seurat::VariableFeaturePlot`:

```R
library(Seurat)

counts <- LayerData(pbmc_small, assay = "RNA", layer = "counts")
assay <- CreateAssay5Object(counts)
test_case <- CreateSeuratObject(assay)

test_case <- NormalizeData(test_case)

test_case <- FindVariableFeatures(test_case)
test_case <- FindVariableFeatures(test_case, selection.method = "mean.var.plot")

VariableFeaturePlot(test_case)
```

Resolves:
- https://github.com/satijalab/seurat/issues/9210
- https://github.com/satijalab/seurat/issues/9215