### PR TITLE
Fix merge.Seurat to ensure layer names are consistent across assays

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SeuratObject
 Title: Data Structures for Single Cell Data
-Version: 5.0.99.9007
+Version: 5.0.99.9008
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Changes:
+- Fix bug in `merge.Seurat` (#246)
 - Fix bug in `VariableFeatures.StdAssay` (#245)
 - Fix bug in `HVFInfo.StdAssay` (#244)
 - Fix bug in `RenameCells.Seurat` (#237)

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -3431,13 +3431,6 @@ merge.Seurat <- function(
         message = "Please provide a cell identifier for each object provided to merge"
       )
     }
-    # for (i in seq_along(along.with = add.cell.ids)) {
-    #   colnames(x = objects[[i]]) <- paste(
-    #     colnames(x = objects[[i]]),
-    #     add.cell.ids[[i]],
-    #     sep = '_'
-    #   )
-    # }
     for (i in 1:length(x = objects)) {
       objects[[i]] <- RenameCells(object = objects[[i]], add.cell.id = add.cell.ids[i])
     }
@@ -3461,10 +3454,6 @@ merge.Seurat <- function(
     simplify = FALSE,
     USE.NAMES = TRUE
   )
-  # TODO: Handle merging v3 and v5 assays
-  # if (any(sapply(X = assay.classes, FUN = length) != 1L)) {
-  #   stop("Cannot merge assays of different classes")
-  # }
   assays.all <- vector(mode = 'list', length = length(x = assays))
   names(x = assays.all) <- assays
   for (assay in assays) {

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -3472,7 +3472,7 @@ merge.Seurat <- function(
     assays.all[[assay]] <- merge(
       x = objects[[idx.x]][[assay]],
       y = lapply(X = objects[idx.y], FUN = '[[', assay),
-      labels = projects,
+      labels = projects[assay.objs],
       add.cell.ids = NULL,
       collapse = collapse,
       merge.data = merge.data

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -2362,11 +2362,11 @@ RenameCells.Seurat <- function(
           sprintf(
             paste(
               "`new.names` should be a named list or else be the same length",
-              "as `colnames(object)`: %i or `Cells(object)`: %i. ",
-              "`length(new.names)` was %i"
+              "as `colnames(object)` (%i) or `Cells(object)` (%i).",
+              "`length(new.names)` was %i."
             ),
-            length(old.names_all),
-            length(old.names_default),
+            length(all.cells),
+            length(default.cells),
             length(new.names)
           )
         )

--- a/tests/testthat/test_seurat.R
+++ b/tests/testthat/test_seurat.R
@@ -1,7 +1,14 @@
 #' Returns a random counts matrix.
 get_random_counts <- function(ncells, nfeatures) {
-  # Populate a `nfeatures` x `ncells` matrix with zeros.
-  counts <- matrix(0, ncol = ncells, nrow = nfeatures)
+  # Instantiate an empty nfeatures by ncells matrix.
+  counts <- matrix(NA, ncol = ncells, nrow = nfeatures)
+  
+  # Populate the matrix one row at a time by generating a negative 
+  # binomial distribution using a random `mu` between 0.1 and 10.
+  for (i in 1:nfeatures) {
+    mu <- runif(1, min = 0.1, max = 10)
+    counts[i, ] <- values <- rnbinom(ncells, mu = mu, size = 1)
+  }
 
   # Assign column and row names to the matrix to label cells and genes.
   colnames(counts) <- paste0("cell", seq(ncol(counts)))


### PR DESCRIPTION
This PR applies a quick fix to the `merge.Seurat` to ensure layer names are consistent across assays, even when merging multiple objects with different combinations of assays. While I was in the neighborhood, I introduced some tests to supplement the ones already in `test_object.R`.

Resolves:
- https://github.com/satijalab/seurat/issues/9462

