### PR TITLE
Add `droplevels` for meta.data in UpdateSeuratObject

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SeuratObject
 Title: Data Structures for Single Cell Data
-Version: 5.0.99.9011
+Version: 5.0.99.9012
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Changes:
+- Update `UpdateSeuratObject` to call `droplevels` on the input's cell-level `meta.data` slot (#247)
 - Drop `Seurat` from `Enhances`; update `.IsFutureSeurat` to avoid calling `requireNamespace('Seurat', ...)` (#250)
 - Update the `VariableFeatures.StdAssay` setter to apply a speedup (#240)
 - Add `SVFInfo.Assay5` & `SpatiallyVariableFeatures.Assay5` (#242)

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -873,7 +873,7 @@ UpdateSeuratObject <- function(object) {
         misc = object@misc %||% list(),
         active.ident = object@ident,
         reductions = new.dr,
-        meta.data = object@meta.data,
+        meta.data = droplevels(object@meta.data),
         tools = list()
       )
       # Run CalcN


### PR DESCRIPTION
Hi Seurat Team,

Quick PR here.  Just adds `droplevels` to `UpdateSeuratObject`.  I chose to add directly to `UpdateSeuratObject` though it could also be incorporated into `droplevels.Seurat` though that adds/changes functionality of that function so didn't do that for now in case that's not desired.

The other place I think this could be helpful would be in `subset.Seurat` so that factor levels in meta.data are updated based on remaining values.  I held off on that for now because wasn't sure that functionality was desired though if team thinks it would be good there too I'm happy to add second commit.

Thanks again for all you do maintaining the package!
Best,
Sam