### PR TITLE
Add `droplevels` call to `subset`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SeuratObject
 Title: Data Structures for Single Cell Data
-Version: 5.0.99.9012
+Version: 5.0.99.9013
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # Unreleased
 
 ## Changes:
-- Update `UpdateSeuratObject` to call `droplevels` on the input's cell-level `meta.data` slot (#247)
+- Update `subset.Seurat` to call `droplevels` on the input's cell-level `meta.data` slot; update `subset.Assay` to call `droplevels` on the input's feature-level `meta.features` slot; update `subset.StdAssay` to call `droplevels` on the input's feature-level `meta.data` slot (#251)
+- Update `UpdateSeuratObject` to call `droplevels` on the input's cell-level `meta.data` slot (@samuel-marsh, #247)
 - Drop `Seurat` from `Enhances`; update `.IsFutureSeurat` to avoid calling `requireNamespace('Seurat', ...)` (#250)
 - Update the `VariableFeatures.StdAssay` setter to apply a speedup (#240)
 - Add `SVFInfo.Assay5` & `SpatiallyVariableFeatures.Assay5` (#242)

--- a/R/assay.R
+++ b/R/assay.R
@@ -1488,7 +1488,13 @@ subset.Assay <- function(x, cells = NULL, features = NULL, ...) {
     new(Class = 'matrix')
   }
   VariableFeatures(object = x) <- VariableFeatures(object = x)[VariableFeatures(object = x) %in% features]
-  slot(object = x, name = 'meta.features') <- x[[]][features, , drop = FALSE]
+
+  # Subset feature-level metadata.
+  meta.features <- x[[]]
+  meta.features <- meta.features[features, , drop = FALSE]
+  meta.features <- droplevels(meta.features)
+  slot(object = x, name = 'meta.features') <- meta.features
+
   validObject(object = x)
   return(x)
 }

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -2484,8 +2484,12 @@ subset.StdAssay <- function(
     orig = features,
     ordered = TRUE
   )
-  # subset the meta.data slot accordingly
-  slot(x, name = "meta.data") <- slot(x, name = "meta.data")[mfeatures, , drop = FALSE]
+
+  # Subset feature-level metadata.
+  meta.data <- slot(x, name = "meta.data")
+  meta.data <- meta.data[mfeatures, , drop = FALSE]
+  meta.data <- droplevels(meta.data)
+  slot(x, name = "meta.data") <- meta.data
 
   # ensure the object is valid
   validObject(x)

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -3717,7 +3717,13 @@ subset.Seurat <- function(
   # Remove metadata for cells not present
   orig.cells <- colnames(x = x)
   cells <- intersect(x = orig.cells, y = cells)
-  slot(object = x, name = 'meta.data') <- x[[]][cells, , drop = FALSE]
+  
+  # Subset cell-level metadata.
+  meta.data <- x[[]]
+  meta.data <- meta.data[cells, , drop = FALSE]
+  meta.data <- droplevels(meta.data)
+  slot(object = x, name = 'meta.data') <- meta.data
+  
   if (!all(orig.cells %in% cells)) {
     # Remove neighbors
     slot(object = x, name = 'neighbors') <- list()


### PR DESCRIPTION
As a follow-up to https://github.com/satijalab/seurat-object/pull/247 this PR applies `droplevels` to the `meta.data` and `meta.feature` dataframes when calling `subset`. 