### PR TITLE
Reduce warnings thrown by VariableFeatures.StdAssay

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SeuratObject
 Title: Data Structures for Single Cell Data
-Version: 5.0.99.9013
+Version: 5.0.99.9014
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -2790,21 +2790,6 @@ tail.Assay5 <- tail.StdAssay
   nfeatures <- nfeatures %||% sum(label_mask)
   # If a ranking is available use it to determine which features are variable.
   feature_mask <- rank_mask %||% label_mask
-  # Warn if `nfeatures` exceeds the number of ranked and/or labelled features.
-  nlabelled <- sum(feature_mask)
-  if (nfeatures > sum(nlabelled)) {
-    warning(
-      sprintf(
-        paste(
-          "`nfeatures` (%d) exceeds the available features (%d) based on the",
-          "provided rank/label metadata. Returning all %d available features."
-        ),
-        nfeatures,
-        nlabelled,
-        nlabelled
-      )
-    )
-  }
 
   # Apply `feature_mask` to feature names from `hvf_info` to get variable
   # feature names.

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -973,7 +973,7 @@ HVFInfo.StdAssay <- function(
   layers_by_method <- .VFMethodsLayers(object, layers = layer, type = "hvf")
 
   if (length(layers_by_method) < 1) {
-    warning("Unable to find any highly variable feature information for the assay.")
+    # If no HVF metadata is present for the specified `assay`, return `NULL`.
     return(NULL)
   }
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/satijalab/seurat-object/pull/245 where I may have gotten a little warning happy. `Seurat`'s test suite is throwing a whole bunch of new warnings that I'd rather not go through and silence, so I'll do the next best thing and avoid raising the them in the first place 🧠 