### PR TITLE
Submit 5.1.0 to CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SeuratObject
 Title: Data Structures for Single Cell Data
-Version: 5.0.99.9016
+Version: 5.1.0
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,13 @@
-# Unreleased
+# SeuratObject 5.1.0
 
 ## Changes:
-- Fix bug in `UpdateSeuratObject` (@neanderthalensis, #210)
-- Fix bug in `WhichCells.Seurat` (@maxim-h, #219)
 - Update `subset.Seurat` to call `droplevels` on the input's cell-level `meta.data` slot; update `subset.Assay` to call `droplevels` on the input's feature-level `meta.features` slot; update `subset.StdAssay` to call `droplevels` on the input's feature-level `meta.data` slot (#251)
 - Update `UpdateSeuratObject` to call `droplevels` on the input's cell-level `meta.data` slot (@samuel-marsh, #247)
 - Drop `Seurat` from `Enhances`; update `.IsFutureSeurat` to avoid calling `requireNamespace('Seurat', ...)` (#250)
 - Update the `VariableFeatures.StdAssay` setter to apply a speedup (#240)
 - Add `SVFInfo.Assay5` & `SpatiallyVariableFeatures.Assay5` (#242)
+- Fix bug in `UpdateSeuratObject` (@neanderthalensis, #210)
+- Fix bug in `WhichCells.Seurat` (@maxim-h, #219)
 - Fix bug in `SpatiallyVariableFeatures.Assay` (#242)
 - Fix bug in `merge.Seurat` (#246)
 - Fix bug in `VariableFeatures.StdAssay` (#245)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,41 +1,13 @@
-# SeuratObject v5.0.2
+# SeuratObject v5.1.0
 
 ## Test environments
-* local ubuntu 20.04 install, R 4.3.2
-* local macOS 14.1, R 4.4.0
-* win-builder (oldrelease, release, devel)
-* mac-builder (devel)
-
-We were unable to test on r-release on mac-builder because the portal seemed to point to the wrong version.
+* Ubuntu 22.04 (Docker container): R-release
+* Ubuntu 24.04 (GitHub Actions Runner): R-oldrelease, R-release, R-devel
+* [win-builder](https://win-builder.r-project.org/): R-oldrelease, R-release, R-devel
+* [macOS builder](https://mac.r-project.org/macbuilder/submit.html): R-release, R-devel
 
 ## R CMD check results
+Status: OK
 
-There were no ERRORs or WARNINGs
-
-There were two NOTEs
-
-> * checking CRAN incoming feasibility ... NOTE
-> Maintainer: 'Rahul Satija <seurat@nygenome.org>'
-> 
-> New maintainer:
->   Rahul Satija <seurat@nygenome.org>
-> Old maintainer(s):
->   Paul Hoffman <seurat@nygenome.org>
-> Suggests or Enhances not in mainstream repositories:
->   BPCells
-> Availability using Additional_repositories specification:
->   BPCells   yes  https://bnprks.r-universe.dev
-
-The new maintainer is Rahul Satija, the email address has remained the same.
-
-> * checking package dependencies ... NOTE
-> Package suggested but not available for checking: 'BPCells'
-
-BPCells is hosted on R-universe and used conditionally in SeuratObject.
-
-## Downstream dependencies
-There are 2 packages that depend on SeuratObject: Seurat, and tidyseurat; this update does not impact their functionality.
-
-There are 9 packages that import SeuratObject: APackOfTheClones, bbknnR, CAMML, Platypus, scAnnotate, scaper, scCustomize, scpoisson, and Signac; this update does not impact their functionality.
-
-There are 10 packages that suggest SeuratObject: cellpypes, CytoSimplex, RESET, rliger, scOntoMatch, SCpubr, singleCellHaystack, SpaTopic, SPECK, and VAM; this update does not impact their functionality.
+## Reverse dependency check results
+We checked 25 reverse dependencies, comparing `R CMD check` results across the CRAN and dev versions of this package, and saw no new problems.


### PR DESCRIPTION
Final updates before submitting `SeuratObject` v5.1.0  to CRAN 🚀 

- [x] Bump version
- [x] Update changelog
- [x] [Reverse Dependency Checks](https://github.com/satijalab/seurat-object/actions/workflows/reverse_dependency_checks.yaml)
- [x] [win-builder](https://win-builder.r-project.org/) (R-release, R-devel, R-oldrel)
- [x] [macOS builder](https://mac.r-project.org/macbuilder/submit.html) (R-release, R-devel)
- [x] Update CRAN comments

---

Historically, we have made major/minor version bumps in release/major.minor.patch branches that are based off `main` and merged into `cran`. The PR from `release/major.minor.patch` to `cran` is left open until the CRAN submission is accepted, at which point the PR is merged.

From this release forward, we will use [release branches with GitLab flow](https://docs.gitlab.co.jp/ee/topics/gitlab_flow.html#release-branches-with-gitlab-flow) as an alternative. 

Each PR into a release branch (e.g `submit/5.1.0`) captures a single CRAN submission. The PR should be merged when the package is submitted and a version tag added if it is accepted. If the submission is rejected, another PR against the release branch should be opened to implement the fix. 

