### PR TITLE
Update branch names

### DIFF
--- a/.github/workflows/merge_checks.yaml
+++ b/.github/workflows/merge_checks.yaml
@@ -2,21 +2,21 @@ name: Pre-Merge Checks
 
 on:
   # Trigger the workflow when a PR is opened/updated against the default or
-  # any release branch.
+  # any stable release branch.
   pull_request:
     branches:
     - main
-    - 'release/*'
-  # Trigger the workflow when commits are pushed to a release branch. 
+    - '*-stable'
+  # Trigger the workflow when commits are pushed to a stable release branch. 
   # Because they are protected branches this workflow is effectively triggered 
   # by three events:
-  # 1. When a release branch is initially created/pushed.
-  # 2. When a PR against the default or any release branch is opened/updated.
-  # 3. When a PR against the default or any release branch is merged.
+  # 1. When a stable release branch is initially created/pushed.
+  # 2. When a PR against the default or any stable release branch is opened/updated.
+  # 3. When a PR against the default or any stable release branch is merged.
   push:
     branches:
     - main
-    - 'release/*'
+    - '*-stable'
   # Allow the workflow to be triggered manually.
   workflow_dispatch:
 

--- a/.github/workflows/release_checks.yaml
+++ b/.github/workflows/release_checks.yaml
@@ -1,19 +1,19 @@
 name: Pre-Release Checks
 
 on:
-  # Trigger the workflow when a PR opened/updated against a release branch.
+  # Trigger the workflow when a PR opened/updated against a stable release branch.
   pull_request:
     branches:
-    - 'release/*'
-  # Trigger the workflow when commits are pushed to a release branch. 
+    - '*-stable'
+  # Trigger the workflow when commits are pushed to a stable release branch. 
   # Because they are protected branches this workflow is effectively triggered 
   # by three events:
-  # 1. When a release branch is initially created/pushed.
-  # 2. When a PR against a release branch is opened/updated.
-  # 3. When a PR against a release branch is merged.
+  # 1. When a stable release branch is initially created/pushed.
+  # 2. When a PR against a stable release branch is opened/updated.
+  # 3. When a PR against a stable release branch is merged.
   push:
     branches:
-    - 'release/*'
+    - '*-stable'
   # Allow the workflow to be triggered manually.
   workflow_dispatch:
 


### PR DESCRIPTION
After giving it some more thought / continuing on with the `Seurat` v5.3.0 release, I've decided to adjust the naming convention for stable release branches to `*-stable` (e.g. `v5.1-stable`) to more closely align with the [Release branches with GitLab flow guide](https://docs.gitlab.co.jp/ee/topics/gitlab_flow.html#release-branches-with-gitlab-flow).

This means that https://github.com/satijalab/seurat-object/pull/253 should have been merging `release/5.1.0` into `v5.1-stable` 👌  