### PR TITLE
fix: don't drop single cell matrix

### DIFF
--- a/R/assay.R
+++ b/R/assay.R
@@ -588,7 +588,7 @@ LayerData.Assay <- function(
     stop('features are not found')
   }
   # Pull the matrix for the cells/features requested
-  return(methods::slot(object = object, name = layer)[features, cells])
+  return(methods::slot(object = object, name = layer)[features, cells, drop = FALSE])
 }
 
 #' @rdname Layers

--- a/tests/testthat/test_objects.R
+++ b/tests/testthat/test_objects.R
@@ -309,6 +309,7 @@ test_that("Specifying idents works", {
 test_that("downsample works", {
   expect_equal(length(x = WhichCells(object = pbmc_small, downsample = 5)), 15)
   expect_equal(length(x = WhichCells(object = pbmc_small, downsample = 100)), 80)
+  expect_equal(dim(LayerData(subset(pbmc_small, cells = 1))), c(230L, 1L))
 })
 
 test_that("passing an expression works", {


### PR DESCRIPTION

This is a fix of an issue that arises when an assay is subset to a single cell. For example, calling for a data layer in such a subsetted would return a numeric vector instead of a Matrix:

```
> seur <- LayerData(subset(pbmc_small, cells = 1))
> class(seur)
[1] "numeric"

> seur <- LayerData(subset(pbmc_small, cells = 1:2))
> class(seur)
[1] "dgCMatrix"
attr(,"package")
[1] "Matrix"
```

This fix makes sure that the returned object is a Matrix, and I have added a test to control for that. This may seem like a specialized case, but it is an issue that creates trouble for certain deep sequenced assays where inspecting individual cells are more common. 