### PR TITLE
Quick fix to how `scale` is handled in `.CropVisiumV2`

### DIFF
--- a/R/fov.R
+++ b/R/fov.R
@@ -237,7 +237,6 @@ CreateFOV.Segmentation <- CreateFOV.Centroids
 #' Internal Cropping Function for VisiumV2
 #'
 #' @inheritParams Crop
-#' @param scale Argument for scaling passed to \code{\link{GetTissueCoordinates}} when \code{coords} is 'plot'
 #'
 #' @return Cropped object
 #'
@@ -255,7 +254,10 @@ CreateFOV.Segmentation <- CreateFOV.Centroids
 
   coords <- match.arg(arg = coords)
   if (coords == "plot" && is.null(x = scale)) {
-    stop("Must provide 'scale' argument when cropping by plot coordinates for VisiumV2 objects", call. = FALSE)
+    warning("scale argument not provided; using default value \"lowres\"", 
+            call. = FALSE, 
+            immediate. = TRUE)
+    scale <- "lowres"
   }
   coords_df <- GetTissueCoordinates(object = object, scale = scale)
 

--- a/R/fov.R
+++ b/R/fov.R
@@ -254,7 +254,7 @@ CreateFOV.Segmentation <- CreateFOV.Centroids
 
   coords <- match.arg(arg = coords)
   if (coords == "plot" && is.null(x = scale)) {
-    warning("scale argument not provided; using default value \"lowres\"", 
+    warning("No scale provided for plot coordinates; using default value \"lowres\"", 
             call. = FALSE, 
             immediate. = TRUE)
     scale <- "lowres"

--- a/R/generics.R
+++ b/R/generics.R
@@ -541,7 +541,6 @@ CreateSeuratObject <- function(
 
 #' Crop Coordinates
 #'
-#' @template param-dots-method
 #' @param object An object
 #' @param x,y Range to crop x/y limits to; if \code{NULL}, uses full range of
 #' \code{x}/\code{y}
@@ -551,6 +550,8 @@ CreateSeuratObject <- function(
 #'  \item \dQuote{\code{tissue}}: Coordinates from
 #'   \code{\link{GetTissueCoordinates}}
 #' }
+#' @param ... Arguments passed to other methods.
+#' Provide \code{scale} when cropping VisiumV2 objects with \code{coords = "plot"}
 #'
 #' @return \code{object} cropped to the region specified by \code{x}
 #' and \code{y}

--- a/R/generics.R
+++ b/R/generics.R
@@ -551,7 +551,7 @@ CreateSeuratObject <- function(
 #'   \code{\link{GetTissueCoordinates}}
 #' }
 #' @param ... Arguments passed to other methods.
-#' Provide \code{scale} when cropping VisiumV2 objects with \code{coords = "plot"}
+#' For VisiumV2 objects with \code{coords = "plot"}, provide \code{scale} (default "lowres")
 #'
 #' @return \code{object} cropped to the region specified by \code{x}
 #' and \code{y}

--- a/man/Crop.Rd
+++ b/man/Crop.Rd
@@ -22,7 +22,8 @@ Crop(object, x = NULL, y = NULL, coords = c("plot", "tissue"), ...)
   \code{\link{GetTissueCoordinates}}
 }}
 
-\item{...}{Arguments passed to other methods}
+\item{...}{Arguments passed to other methods.
+Provide \code{scale} when cropping VisiumV2 objects with \code{coords = "plot"}}
 }
 \value{
 \code{object} cropped to the region specified by \code{x}

--- a/man/Crop.Rd
+++ b/man/Crop.Rd
@@ -23,7 +23,7 @@ Crop(object, x = NULL, y = NULL, coords = c("plot", "tissue"), ...)
 }}
 
 \item{...}{Arguments passed to other methods.
-Provide \code{scale} when cropping VisiumV2 objects with \code{coords = "plot"}}
+For VisiumV2 objects with \code{coords = "plot"}, provide \code{scale} (default "lowres")}
 }
 \value{
 \code{object} cropped to the region specified by \code{x}


### PR DESCRIPTION
- Add default value ("lowres") for scaling when `coords="plot"`. 
- Change error to warning when `scale` is not provided.
- Update documentation accordingly.