### PR TITLE
Add assay parameter to subset.Seurat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SeuratObject
 Title: Data Structures for Single Cell Data
-Version: 5.4.0
+Version: 5.4.0.9000
 Authors@R: c(
   person(given = 'Paul', family = 'Hoffman', email = 'hoff0792@alumni.umn.edu', role = 'aut', comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = 'Rahul', family = 'Satija', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0001-9448-8833')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 ## Changes:
-- Add `assay` parameter to `subset.Seurat` to specify the default assay for expression filters
+- Add `assay` parameter to `subset.Seurat` to specify the default assay for expression filters ([#292](https://github.com/satijalab/seurat-object/pull/292))
 
 # SeuratObject 5.4.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Changes:
+- Add `assay` parameter to `subset.Seurat` to specify the default assay for expression filters
+
 # SeuratObject 5.4.0
 
 ## Changes:

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -3703,6 +3703,11 @@ split.Seurat <- function(
 #' @param subset Logical expression indicating features/variables to keep
 #' @param cells,j A vector of cell names or indices to keep
 #' @param features,i A vector of feature names or indices to keep
+#' @param assay Name of the assay used as the default when resolving
+#' expression filters (\code{subset = ...}) and feature names. Defaults to
+#' \code{DefaultAssay(x)}. The returned object's default assay is set to this
+#' value. Other assays are still subset to the same cells; if \code{features}
+#' is provided, it is applied to every assay.
 #' @param idents A vector of identity classes to keep
 #' @param droplevels.meta.data logical, whether to drop unused factor levels from meta.data
 #' columns after subsetting.  Default is FALSE.
@@ -3738,6 +3743,9 @@ split.Seurat <- function(
 #' # subset retaining only specific set of features
 #' subset(pbmc_small, features = VariableFeatures(object = pbmc_small))
 #'
+#' # evaluate an expression filter against a specific assay
+#' subset(pbmc_small, subset = LYZ > 1, assay = "RNA")
+#'
 #' # subset and drop unused levels from meta.data columns after subset
 #' subset(pbmc_small, idents = '0', droplevels.meta.data = TRUE)
 #'
@@ -3746,11 +3754,15 @@ subset.Seurat <- function(
   subset,
   cells = NULL,
   features = NULL,
+  assay = NULL,
   idents = NULL,
   return.null = FALSE,
   droplevels.meta.data = FALSE,
   ...
 ) {
+  assay <- assay %||% DefaultAssay(object = x)
+  assay <- arg_match(arg = assay, values = Assays(object = x))
+  DefaultAssay(object = x) <- assay
   # var.features <- VariableFeatures(object = x)
   if (!missing(x = subset)) {
     subset <- enquo(arg = subset)

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -3703,14 +3703,14 @@ split.Seurat <- function(
 #' @param subset Logical expression indicating features/variables to keep
 #' @param cells,j A vector of cell names or indices to keep
 #' @param features,i A vector of feature names or indices to keep
+#' @param idents A vector of identity classes to keep
+#' @param droplevels.meta.data logical, whether to drop unused factor levels from meta.data
+#' columns after subsetting.  Default is FALSE.
 #' @param assay Name of the assay used as the default when resolving
 #' expression filters (\code{subset = ...}) and feature names. Defaults to
 #' \code{DefaultAssay(x)}. The returned object's default assay is set to this
 #' value. Other assays are still subset to the same cells; if \code{features}
 #' is provided, it is applied to every assay.
-#' @param idents A vector of identity classes to keep
-#' @param droplevels.meta.data logical, whether to drop unused factor levels from meta.data
-#' columns after subsetting.  Default is FALSE.
 #' @param ... Arguments passed to \code{\link{WhichCells}}
 #'
 #' @return \code{subset}: A subsetted \code{Seurat} object
@@ -3754,15 +3754,15 @@ subset.Seurat <- function(
   subset,
   cells = NULL,
   features = NULL,
-  assay = NULL,
   idents = NULL,
   return.null = FALSE,
   droplevels.meta.data = FALSE,
+  assay = NULL,
   ...
 ) {
-  assay <- assay %||% DefaultAssay(object = x)
-  assay <- arg_match(arg = assay, values = Assays(object = x))
-  DefaultAssay(object = x) <- assay
+  assay.use <- assay %||% DefaultAssay(object = x)
+  assay.use <- arg_match(arg = assay.use, values = Assays(object = x))
+  DefaultAssay(object = x) <- assay.use
   # var.features <- VariableFeatures(object = x)
   if (!missing(x = subset)) {
     subset <- enquo(arg = subset)
@@ -3806,21 +3806,21 @@ subset.Seurat <- function(
   }
   Idents(object = x, drop = TRUE) <- Idents(object = x)[cells]
   # Filter Assay objects
-  for (assay in Assays(object = x)) {
-    if (length(x = intersect(colnames(x = x[[assay]]), cells)) == 0) {
-      message(assay, " assay doesn't leave any cells, so it is removed")
-      if (DefaultAssay(x) == assay) {
+  for (assay.name in Assays(object = x)) {
+    if (length(x = intersect(colnames(x = x[[assay.name]]), cells)) == 0) {
+      message(assay.name, " assay doesn't leave any cells, so it is removed")
+      if (DefaultAssay(x) == assay.name) {
         stop('No cells left in the default assay, please change the default assay')
       }
-      slot(object = x, name = 'assays')[[assay]] <- NULL
+      slot(object = x, name = 'assays')[[assay.name]] <- NULL
     } else {
-      assay.features <- features %||% rownames(x = x[[assay]])
+      assay.features <- features %||% rownames(x = x[[assay.name]])
       suppressWarnings(
-        expr = slot(object = x, name = 'assays')[[assay]] <- tryCatch(
+        expr = slot(object = x, name = 'assays')[[assay.name]] <- tryCatch(
           # because subset is also an argument, we need to explictly use the base::subset function
           expr = suppressWarnings(
             expr = base::subset(
-              x = x[[assay]],
+              x = x[[assay.name]],
               cells = cells,
               features = assay.features
             ),
@@ -3865,10 +3865,10 @@ subset.Seurat <- function(
   }
   # Recalculate nCount and nFeature
   if (!is.null(features)) {
-    for (assay in .FilterObjects(object = x, classes.keep = 'Assay')) {
-      n.calc <- CalcN(object = x[[assay]])
+    for (assay.name in .FilterObjects(object = x, classes.keep = 'Assay')) {
+      n.calc <- CalcN(object = x[[assay.name]])
       if (!is.null(x = n.calc)) {
-        names(x = n.calc) <- paste(names(x = n.calc), assay, sep = '_')
+        names(x = n.calc) <- paste(names(x = n.calc), assay.name, sep = '_')
         suppressWarnings(
           expr = x[[names(x = n.calc)]] <- n.calc,
           classes = 'validationWarning'

--- a/man/subset.Seurat.Rd
+++ b/man/subset.Seurat.Rd
@@ -11,10 +11,10 @@
   subset,
   cells = NULL,
   features = NULL,
-  assay = NULL,
   idents = NULL,
   return.null = FALSE,
   droplevels.meta.data = FALSE,
+  assay = NULL,
   ...
 )
 
@@ -29,12 +29,6 @@
 
 \item{features, i}{A vector of feature names or indices to keep}
 
-\item{assay}{Name of the assay used as the default when resolving
-expression filters (\code{subset = ...}) and feature names. Defaults to
-\code{DefaultAssay(x)}. The returned object's default assay is set to this
-value. Other assays are still subset to the same cells; if \code{features}
-is provided, it is applied to every assay.}
-
 \item{idents}{A vector of identity classes to keep}
 
 \item{return.null}{If no cells are requested, return a \code{NULL};
@@ -42,6 +36,12 @@ by default, throws an error}
 
 \item{droplevels.meta.data}{logical, whether to drop unused factor levels from meta.data
 columns after subsetting.  Default is FALSE.}
+
+\item{assay}{Name of the assay used as the default when resolving
+expression filters (\code{subset = ...}) and feature names. Defaults to
+\code{DefaultAssay(x)}. The returned object's default assay is set to this
+value. Other assays are still subset to the same cells; if \code{features}
+is provided, it is applied to every assay.}
 
 \item{...}{Arguments passed to \code{\link{WhichCells}}}
 }

--- a/man/subset.Seurat.Rd
+++ b/man/subset.Seurat.Rd
@@ -11,6 +11,7 @@
   subset,
   cells = NULL,
   features = NULL,
+  assay = NULL,
   idents = NULL,
   return.null = FALSE,
   droplevels.meta.data = FALSE,
@@ -27,6 +28,12 @@
 \item{cells, j}{A vector of cell names or indices to keep}
 
 \item{features, i}{A vector of feature names or indices to keep}
+
+\item{assay}{Name of the assay used as the default when resolving
+expression filters (\code{subset = ...}) and feature names. Defaults to
+\code{DefaultAssay(x)}. The returned object's default assay is set to this
+value. Other assays are still subset to the same cells; if \code{features}
+is provided, it is applied to every assay.}
 
 \item{idents}{A vector of identity classes to keep}
 
@@ -67,6 +74,9 @@ subset(pbmc_small, idents = '0', invert = TRUE)
 
 # subset retaining only specific set of features
 subset(pbmc_small, features = VariableFeatures(object = pbmc_small))
+
+# evaluate an expression filter against a specific assay
+subset(pbmc_small, subset = LYZ > 1, assay = "RNA")
 
 # subset and drop unused levels from meta.data columns after subset
 subset(pbmc_small, idents = '0', droplevels.meta.data = TRUE)

--- a/tests/testthat/test_objects.R
+++ b/tests/testthat/test_objects.R
@@ -375,6 +375,59 @@ test_that("Top works", {
   expect_equal(length(tpc1.sub[[2]]), 39)
 })
 
+# Tests for subset.Seurat assay argument
+# ----------------------------------------------------------------------------
+context("subset")
+
+test_that("subset with assay does not change the caller's DefaultAssay", {
+  orig <- DefaultAssay(pbmc_small)
+  genes <- head(rownames(pbmc_small[["RNA"]]), 10)
+  subset(pbmc_small, features = genes, assay = "RNA")
+  expect_equal(DefaultAssay(pbmc_small), orig)
+})
+
+test_that("subset with assay sets DefaultAssay on the returned object", {
+  obj <- pbmc_small
+  suppressWarnings(obj[["RNA_hi"]] <- obj[["RNA"]])
+  Key(obj[["RNA_hi"]]) <- "rnahi_"
+  DefaultAssay(object = obj) <- "RNA_hi"
+  out <- subset(obj, subset = LYZ > 1, assay = "RNA")
+  expect_equal(DefaultAssay(out), "RNA")
+})
+
+test_that("subset errors on invalid assay name", {
+  expect_error(
+    subset(pbmc_small, features = rownames(pbmc_small)[1:5], assay = "NOTANASSAY")
+  )
+})
+
+test_that("subset with assay filters expression by the specified assay", {
+  obj <- pbmc_small
+  suppressWarnings(obj[["RNA_hi"]] <- obj[["RNA"]])
+  Key(obj[["RNA_hi"]]) <- "rnahi_"
+  gene <- "LYZ"
+  rna.data <- as.matrix(GetAssayData(object = obj, assay = "RNA", layer = "data"))
+  hi.data <- rna.data
+  hi.data[gene, ] <- rna.data[gene, ] + 3
+  LayerData(object = obj, assay = "RNA_hi", layer = "data") <- hi.data
+
+  x <- 4.5
+  cells.rna <- colnames(x = obj)[rna.data[gene, ] > x]
+  cells.hi <- colnames(x = obj)[hi.data[gene, ] > x]
+  expect_false(setequal(cells.rna, cells.hi))
+
+  DefaultAssay(object = obj) <- "RNA_hi"
+  expect_false(setequal(cells.rna, WhichCells(object = obj, expression = LYZ > x)))
+
+  obj.rna <- subset(obj, subset = LYZ > x, assay = "RNA")
+  obj.hi <- subset(obj, subset = LYZ > x, assay = "RNA_hi")
+
+  expect_equal(Cells(obj.rna), cells.rna)
+  expect_equal(Cells(obj.hi), cells.hi)
+  expect_true(all(GetAssayData(obj.rna, assay = "RNA", layer = "data")[gene, ] > x))
+  expect_true(all(GetAssayData(obj.hi, assay = "RNA_hi", layer = "data")[gene, ] > x))
+})
+
 # Tests for UpdateSeuratObject
 # ----------------------------------------------------------------------------
 context("UpdateSeuratObject")


### PR DESCRIPTION
# Summary
Adds an assay argument to subset.Seurat so expression filters (e.g. subset = LYZ > 1) are evaluated against a chosen assay instead of requiring callers to temporarily change DefaultAssay.

Closes #291.

# Changes
- Add assay = NULL to subset.Seurat, following the same a`ssay %||% DefaultAssay` / arg_match pattern used by FetchData and related methods
- Set the default assay on the local object copy before WhichCells runs, so bare gene names in `subset = ...` resolve against the requested assay
- Document behavior in roxygen and regenerate man/subset.Seurat.Rd
- Add unit tests for invalid assay names, caller DefaultAssay preservation, returned object DefaultAssay, and multi-assay expression filtering

## Behavior notes
- The returned object's default assay is set to assay
- The input object's default assay is unchanged (copy-on-modify)
- features is still applied to every assay; only expression filtering is assay-scoped via the default assay
<!--
Thanks for your interest in contributing! 

Please refer the contributor's guide for instructions on submitting a pull request:
https://github.com/satijalab/seurat-object/wiki#contributors-guide
-->
